### PR TITLE
Cleaning up error messages for parsing the config file

### DIFF
--- a/lib/configuration.ml
+++ b/lib/configuration.ml
@@ -45,8 +45,16 @@ module ParseConfig = struct
         | ShellCommand -> line_num + 2
       in
       match err with
-      | `ReferParse (line_num, key)  -> "TODO"
-      | `ConfigData (line_num, line) -> "TODO"
+      | `ConfigData (line_num, key)  ->
+          Printf.sprintf
+            "Config Data Error: (line %d) Missing key '%s'"
+            (config_error_line key line_num)
+            (string_of_config_key key)
+      | `ReferParse (line_num, line) ->
+          Printf.sprintf
+            "Refer Parse Error: (line %d) Cannot parse '%s'"
+            line_num
+            line
   end
 
   type config_entry =
@@ -102,6 +110,5 @@ module ParseConfig = struct
       (Ok Dict.empty)
       (Refer.of_string config_str)
 
-  let parse_config_file path_to_config =
-    path_to_config |> Prelude.readfile |> parse_config_str
+  let parse_config_file = Prelude.readfile >> parse_config_str
 end

--- a/lib/errorHandling.ml
+++ b/lib/errorHandling.ml
@@ -7,7 +7,7 @@ end
 
 module _ : ERROR with
   type t = [
-    | `ReferParse of string
-    | `ConfigData of string
+    | `ConfigData of int * Configuration.ParseConfig.config_key
+    | `ReferParse of int * string
   ] = Configuration.ParseConfig.Error
 

--- a/tests/config_tests.ml
+++ b/tests/config_tests.ml
@@ -164,8 +164,7 @@ let check_error result error =
 let missing_cs_error_msg =
   check_error
     (parse_config_str missing_cs)
-    (`ConfigData
-      "Entry starting at Line 1, Config File Error: no script path given")
+    (`ConfigData (1, ShellCommand))
 
 let bad_refer_cs =
 "%source_type a
@@ -181,8 +180,7 @@ not a real line
 let bad_refer_cs_msg =
   check_error
     (parse_config_str bad_refer_cs)
-      (`ReferParse
-        "Line 5, Refer Parse Error: Cannot parse 'not a real line'")
+      (`ReferParse (5, "not a real line"))
 
 let double_entry_cs =
 "%source_type a


### PR DESCRIPTION
A very simple fix that cleans up `configuration.ml`, mostly to help me sleep at night. Now there isn't any error message manipulation in the parsing code.