### PR TITLE
17 update acopy and amap

### DIFF
--- a/lib/lib.ml
+++ b/lib/lib.ml
@@ -125,18 +125,18 @@ module Conversion_ocamlnet (*: CONVERT*) = struct
 let convert script str = let args = split script in
   Unix.Proc.rw args str
 
-  let transform hd bd trans_entry =
-    let open Netmime in
-    let open Configuration.Formats in
-    let data = bd # value in
-    let conv_data = convert trans_entry.shell_command data in
-    let conv_hd =
-      basic_mime_header ["content-type", trans_entry.target_type]
-    in
-    match trans_entry.variety with
-    | NoChange -> hd,`Body bd
-    | DataOnly -> hd, `Body (memory_mime_body (conv_data))
-    | DataAndHeader -> conv_hd, `Body (memory_mime_body (conv_data))
+let transform hd bd trans_entry =
+  let open Netmime in
+  let open Configuration.Formats in
+  let data = bd # value in
+  let conv_data = convert trans_entry.shell_command data in
+  let conv_hd =
+    basic_mime_header ["content-type", trans_entry.target_type]
+  in
+  match trans_entry.variety with
+  | NoChange -> hd,`Body bd
+  | DataOnly -> hd, `Body (memory_mime_body (conv_data))
+  | DataAndHeader -> conv_hd, `Body (memory_mime_body (conv_data))
 
   (* Notes: Content-Disposition headers provide information about how
      to present a message or a body part. When a body part is to be

--- a/lib/lib.ml
+++ b/lib/lib.ml
@@ -145,7 +145,7 @@ let transform hd bd (trans_entry : Configuration.Formats.transform_data) =
   (** apply an input function f to every attachment in an email
       parsetree; note that this is not a real functorial map, which
       means we will probably be renaming it in the future *)
-  let amap ?(f = fun err -> Printf.printf "%s\n" (Error.message err)) dict (tree:parsetree) =
+  let amap ?(f = fun err -> Printf.printf "%s\n" (Error.message err)) dict (tree : parsetree) =
     let ( let* ) = Result.(>>=) in
     let err_handler part e = match e with
       | #LogError.t as y -> f y; Ok [part]
@@ -173,7 +173,7 @@ let transform hd bd (trans_entry : Configuration.Formats.transform_data) =
         Ok (header, `Parts cmp_lst)
 
 (*?(f = Printf.printf (Error.message))*)
-let acopy ?(f = fun err -> Printf.printf "%s\n" (Error.message err)) dict (tree:parsetree) =
+let acopy ?(f = fun err -> Printf.printf "%s\n" (Error.message err)) dict (tree : parsetree) =
   let ( let* ) = Result.(>>=) in
   let err_handler part e = match e with
     | #LogError.t as y -> f y; Ok [part]
@@ -189,7 +189,7 @@ let acopy ?(f = fun err -> Printf.printf "%s\n" (Error.message err)) dict (tree:
              let* trans_lst = Result.of_option 
              (`ConfigData ("source: '" ^ src ^ "' not found")) (Configuration.Formats.Dict.find_opt src dict)  in
              let* next_lst = copy_or_skip hd rs                                                                in
-             let conv_lst = (List.map (transform bhd b) trans_lst) @ [(bhd, `Body b)]                          in
+             let conv_lst = (List.map (transform bhd b) trans_lst)                                             in
              Ok (conv_lst @ next_lst)) (err_handler (bhd, `Body b))
           | (phd, `Parts p) :: rs -> 
             Result.on_error
@@ -221,7 +221,7 @@ let acopy ?(f = fun err -> Printf.printf "%s\n" (Error.message err)) dict (tree:
       channel_writer ;
     Stdlib.Buffer.contents buf
 
-  let acopy_email str f = str
+  let acopy_email _ = assert false
 
   (** predicate for email parts that are attachments *)
   let is_attachment tree =
@@ -348,7 +348,7 @@ module REPLTesting = struct
 
   let test_acopy () =
     let ( let* ) = Result.(>>=) in
-    let tree = tree () in
+    let tree = err_tree () in
     let* dict = Result.witherrc (`DummyError) (dict ()) in
     acopy dict tree
 

--- a/lib/lib.ml
+++ b/lib/lib.ml
@@ -26,11 +26,6 @@ module Error : ERROR with
     | #Configuration.ParseConfig.Error.t as e -> Configuration.ParseConfig.Error.message e
 end
 
-module Error = struct
-  type t =
-    [ `DummyError ] (* For testing *)
-end
-
 (* library code for attachment converter goes here *)
 module type CONVERT =
 sig

--- a/lib/lib.ml
+++ b/lib/lib.ml
@@ -189,7 +189,7 @@ let acopy ?(f = fun err -> Printf.printf "%s\n" (Error.message err)) dict (tree 
              let* trans_lst = Result.of_option 
              (`ConfigData ("source: '" ^ src ^ "' not found")) (Configuration.Formats.Dict.find_opt src dict)  in
              let* next_lst = copy_or_skip hd rs                                                                in
-             let conv_lst = (List.map (transform bhd b) trans_lst)                                             in
+             let conv_lst = (List.map (transform bhd b) trans_lst) @ [(bhd, `Body b)]                          in
              Ok (conv_lst @ next_lst)) (err_handler (bhd, `Body b))
           | (phd, `Parts p) :: rs -> 
             Result.on_error

--- a/lib/lib.ml
+++ b/lib/lib.ml
@@ -117,7 +117,7 @@ let transform hd bd (trans_entry : Configuration.Formats.transform_data) =
   (** apply an input function f to every attachment in an email
       parsetree; note that this is not a real functorial map, which
       means we will probably be renaming it in the future *)
-  let rec amap ?(no_op = true) f dict tree =
+  let amap ?(no_op = true) f dict tree =
     let ( let* ) = Result.(>>=) in
     let err_handler e = if no_op then Error e else (f e; Ok []) in
     match tree with

--- a/lib/lib.ml
+++ b/lib/lib.ml
@@ -142,10 +142,9 @@ let convert script str = let args = split script in
      to present a message or a body part. When a body part is to be
      treated as an attached file, the Content-Disposition header will
      include a file name parameter. *)
-
-  (** apply an input function f to every attachment in an email
-      parsetree; note that this is not a real functorial map, which
-      means we will probably be renaming it in the future *)
+  
+  (**applies conversions to the attachment elements of the parsetree, replacing the original
+     attachment with the converted versions in the returned parsetree*)
   let amap ?(f = fun err -> Printf.printf "%s\n" (Error.message err)) dict (tree : parsetree) =
     let ( let* ) = Result.(>>=) in
     let err_handler part e = match e with
@@ -173,7 +172,8 @@ let convert script str = let args = split script in
         in let* cmp_lst = copy_or_skip header p_lst in
         Ok (header, `Parts cmp_lst)
 
-(*?(f = Printf.printf (Error.message))*)
+(**applies conversions to the attachment elements of the parsetree, leaving the original 
+   attachment with the converted versions in the returned parsetree*)
 let acopy ?(f = fun err -> Printf.printf "%s\n" (Error.message err)) dict (tree : parsetree) =
   let ( let* ) = Result.(>>=) in
   let err_handler part e = match e with


### PR DESCRIPTION
The FatalError and LogError types will eventually include additional values. The plan for right now is that all errors pertaining to individual attachments (ie. improperly formatted headers, MBOX issues, etc.) will be errors that we write to a log or to stdout and continue execution. Both 'acopy' and 'amap', for instance, will continue converting the remaining attachments if there is an exception in getting the 'content-type' from an attachment header. All errors related to configuration will be fatal in that they halt execution and return the error type. For right now, if a source type cannot be found, 'acopy' and 'amap' will return a fatal error--this might be better as log error as well, but for right now it's probably a good idea to shut everything down in case there are multiple attachments of this particular source type.