### PR TITLE
37 move to cmdliner

### DIFF
--- a/dune
+++ b/dune
@@ -5,7 +5,7 @@
 (executable
  (name main)
  (public_name attachment-converter)
- (libraries prelude lib mrmime threads netstring unix))
+ (libraries prelude lib mrmime threads netstring unix cmdliner))
 
 (env
   (dev                                  ; make warnings non-fatal

--- a/main.ml
+++ b/main.ml
@@ -9,27 +9,32 @@
 open Prelude
 open Cmdliner
 
-type parsed_in = (string * in_channel)
-type channel_parser = string -> (parsed_in, [`Msg of string]) Stdlib.result
-type channel_printer = parsed_in Arg.printer
+type cmd_input = [`Stdin | `File of string]
+type cmd_input_parser = string -> (cmd_input, [`Msg of string]) Stdlib.result
+type cmd_input_printer = cmd_input Arg.printer
 
 (*(string -> ('a, [ `Msg of string ]) Stdlib.result*)
-let channel_parser str = 
+let cmd_input_parser str = 
   if Sys.file_exists str 
-  then Ok (str, (open_in str))
+  then Ok (`File str)
   else Error (`Msg ("File: " ^ str ^ " does not exist."))
 
 (*Format.formatter -> `a -> unit*)
-let channel_printer fmt input = match input with
-  (s,_) -> Format.pp_print_string fmt s
+let cmd_input_printer fmt input = let str = 
+  match input with
+    | `Stdin -> "STDIN"
+    | `File fn -> fn
+  in Format.pp_print_string fmt str
 
 (*parsed_in conv*)
-let channel_conv = Arg.conv (channel_parser, channel_printer)
+let cmd_input_conv = Arg.conv (cmd_input_parser, cmd_input_printer)
 
-let report ?(params = false) () =
+let report ?(params = false) inp =
   let open Lib.Report                                  in
   let module M =  Map.Make(String)                     in
-  let types    = content_types ~params:params stdin    in
+  let types    = match inp with
+    | `File fn -> within (content_types ~params:params) fn
+    | _ -> content_types ~params:params stdin          in
   print "Content Types:";
   M.iter
     (fun k v -> print ("  " ^ k ^ " : " ^ (Int.to_string v)))
@@ -37,14 +42,16 @@ let report ?(params = false) () =
 
 let default_config_name = ".default-config"
 
-let convert ic =
+let convert inp =
   let open Lib.Convert.Conversion_ocamlnet in
   let open Lib.Configuration.ParseConfig   in
   let open Lib.ErrorHandling               in
   if   Sys.file_exists default_config_name
   then let converted_email =
          let  ( let* ) = Result.(>>=)                          in
-         let  input    = read ic                               in
+         let  input    = match inp with
+          | `File fn -> readfile fn
+          | _ -> read stdin                                    in
          let* config   = parse_config_file default_config_name in
          acopy_email config input
        in
@@ -54,20 +61,20 @@ let convert ic =
   else Printf.printf "Error: missing config file '%s'\n" default_config_name
 
 (*params matched first in the case both report and params are true*)
-let convert_wrapper rpt params inp =
-  match inp with (_,ic) -> if params then report ~params:true ()
-  else if rpt then report ()
-  else convert ic
+let convert_wrapper rpt rpt_p inp =
+  if rpt_p then report ~params:true inp
+  else if rpt then report inp
+  else convert inp
 
 let input_t = let doc = "Input file to be converted." in
-Arg.(value & pos 0 channel_conv ("STDIN", stdin) & info [] ~doc)
-
-let report_t = let doc = "Provides a list of all attachment types in a given mailbox." in
-Arg.(value & flag & info ["r"; "report"] ~doc)
+Arg.(value & pos 0 cmd_input_conv `Stdin & info [] ~doc)
 
 let report_params_t = let doc = "Prints a list of all MIME types in the input along with 
 all header and field parameters that go with it." in
 Arg.(value & flag & info ["p"; "report-params"] ~doc)
+
+let report_t = let doc = "Provides a list of all attachment types in a given mailbox." in
+Arg.(value & flag & info ["r"; "report"] ~doc)
 
 let convert_t = Term.(const convert_wrapper $ report_t $ report_params_t $ input_t)
 

--- a/main.ml
+++ b/main.ml
@@ -13,20 +13,17 @@ type cmd_input = [`Stdin | `File of string]
 type cmd_input_parser = string -> (cmd_input, [`Msg of string]) Stdlib.result
 type cmd_input_printer = cmd_input Arg.printer
 
-(*(string -> ('a, [ `Msg of string ]) Stdlib.result*)
 let cmd_input_parser str = 
   if Sys.file_exists str 
   then Ok (`File str)
   else Error (`Msg ("File: " ^ str ^ " does not exist."))
 
-(*Format.formatter -> `a -> unit*)
 let cmd_input_printer fmt input = let str = 
   match input with
     | `Stdin -> "STDIN"
     | `File fn -> fn
   in Format.pp_print_string fmt str
 
-(*parsed_in conv*)
 let cmd_input_conv = Arg.conv (cmd_input_parser, cmd_input_printer)
 
 let report ?(params = false) inp =
@@ -60,7 +57,6 @@ let convert inp =
        | Ok converted -> write stdout converted
   else Printf.printf "Error: missing config file '%s'\n" default_config_name
 
-(*params matched first in the case both report and params are true*)
 let convert_wrapper rpt rpt_p inp =
   if rpt_p then report ~params:true inp
   else if rpt then report inp

--- a/main.ml
+++ b/main.ml
@@ -71,7 +71,7 @@ Arg.(value & pos 0 cmd_input_conv `Stdin & info [] ~doc)
 
 let report_params_t = let doc = "Prints a list of all MIME types in the input along with 
 all header and field parameters that go with it." in
-Arg.(value & flag & info ["p"; "report-params"] ~doc)
+Arg.(value & flag & info ["report-params"] ~doc)
 
 let report_t = let doc = "Provides a list of all attachment types in a given mailbox." in
 Arg.(value & flag & info ["r"; "report"] ~doc)
@@ -79,7 +79,7 @@ Arg.(value & flag & info ["r"; "report"] ~doc)
 let convert_t = Term.(const convert_wrapper $ report_t $ report_params_t $ input_t)
 
 let cmd = let doc = "Converts email attachments." in
-  let info = Cmd.info "convert" ~doc in
+  let info = Cmd.info "attachment-converter" ~doc in
   Cmd.v info convert_t
 
 let main () = exit (Cmd.eval cmd)

--- a/main.ml
+++ b/main.ml
@@ -7,6 +7,24 @@
  *)
 
 open Prelude
+open Cmdliner
+
+type parsed_in = (string * in_channel)
+type channel_parser = string -> (parsed_in, [`Msg of string]) Stdlib.result
+type channel_printer = parsed_in Arg.printer
+
+(*(string -> ('a, [ `Msg of string ]) Stdlib.result*)
+let channel_parser str = 
+  if Sys.file_exists str 
+  then Ok (str, (open_in str))
+  else Error (`Msg ("File: " ^ str ^ " does not exist."))
+
+(*Format.formatter -> `a -> unit*)
+let channel_printer fmt input = match input with
+  (s,_) -> Format.pp_print_string fmt s
+
+(*parsed_in conv*)
+let channel_conv = Arg.conv (channel_parser, channel_printer)
 
 let report ?(params = false) () =
   let open Lib.Report                                  in
@@ -19,14 +37,14 @@ let report ?(params = false) () =
 
 let default_config_name = ".default-config"
 
-let convert () =
+let convert ic =
   let open Lib.Convert.Conversion_ocamlnet in
   let open Lib.Configuration.ParseConfig   in
   let open Lib.ErrorHandling               in
   if   Sys.file_exists default_config_name
   then let converted_email =
          let  ( let* ) = Result.(>>=)                          in
-         let  input    = read stdin                            in
+         let  input    = read ic                               in
          let* config   = parse_config_file default_config_name in
          acopy_email config input
        in
@@ -35,17 +53,31 @@ let convert () =
        | Ok converted -> write stdout converted
   else Printf.printf "Error: missing config file '%s'\n" default_config_name
 
-(* A _very_ minimal executable *)
-let () =
-  if   Array.length Sys.argv > 1
-  then match Sys.argv.(1) with
-       | "--report"        -> report ()
-       | "--report-params" -> report ~params:true ()
-       | unknown_flag      -> Printf.printf
-                                "Error: do not recognize flag '%s'\n"
-                                unknown_flag
-  else convert ()
+(*params matched first in the case both report and params are true*)
+let convert_wrapper rpt params inp =
+  match inp with (_,ic) -> if params then report ~params:true ()
+  else if rpt then report ()
+  else convert ic
 
+let input_t = let doc = "Input file to be converted." in
+Arg.(value & pos 0 channel_conv ("STDIN", stdin) & info [] ~doc)
+
+let report_t = let doc = "Provides a list of all attachment types in a given mailbox." in
+Arg.(value & flag & info ["r"; "report"] ~doc)
+
+let report_params_t = let doc = "Prints a list of all MIME types in the input along with 
+all header and field parameters that go with it." in
+Arg.(value & flag & info ["p"; "report-params"] ~doc)
+
+let convert_t = Term.(const convert_wrapper $ report_t $ report_params_t $ input_t)
+
+let cmd = let doc = "Converts email attachments." in
+  let info = Cmd.info "convert" ~doc in
+  Cmd.v info convert_t
+
+let main () = exit (Cmd.eval cmd)
+
+let () = main ()
 (*
  * Copyright (c) 2021 Matt Teichman
  *


### PR DESCRIPTION
The help page and other automatically generated information (ie. the descriptions for the different switches) are all that's included for right now. Later on, if there are other sections we'd like to include (a bug reports section, etc), we can add them in easily using the cmdliner template.