### PR TITLE
46 hash original attachment for reference in converted attachment

### DIFF
--- a/lib/convert.ml
+++ b/lib/convert.ml
@@ -290,19 +290,21 @@ module Conversion_ocamlnet_F (C: ATTACHMENT_CONVERTER) = struct
           | Ok dis_hv -> Ok (process dis_hv)
           | Error _ -> Ok dis
     in
-    let fields =
+    let meta_header_hv =
+      HeaderValue.to_string
+        (create_meta_header_val
+          src
+          trans_entry.target_type
+          ts
+          trans_entry.convert_id
+          (string_of_int hashed_data))
+     in
+     let fields =
       Assoc.(
         replace ("Content-Type", new_ct) >>
         replace ("Content-Transfer-Encoding", "base64") >>
         replace ("Content-Disposition", new_dis) >>
-        add meta_header_name
-          (HeaderValue.to_string
-            (create_meta_header_val
-              src
-              trans_entry.target_type
-              ts
-              trans_entry.convert_id
-              (string_of_int hashed_data))))
+        add meta_header_name meta_header_hv)
           (hd # fields)
     in
       Ok (Netmime.basic_mime_header fields)
@@ -359,7 +361,7 @@ module Conversion_ocamlnet_F (C: ATTACHMENT_CONVERTER) = struct
           let* hv = HeaderValue.parse ct in
           Ok (HeaderValue.head hv)
 
-  let conversion_table dict tree copy =
+  let already_converted tree =
     let ( let* ) = Result.bind in
     let rec build lst tree =
       match tree with

--- a/lib/convert.ml
+++ b/lib/convert.ml
@@ -1,4 +1,5 @@
 open Prelude
+open Utils
 
 module type ATTACHMENT_CONVERTER =
 sig
@@ -27,302 +28,260 @@ sig
   val acopy_mbox : Configuration.Formats.t -> in_channel -> (unit, error) result
 end
 
-module Conversion_ocamlnet_F (C: ATTACHMENT_CONVERTER) = struct
-
-  module Error = struct
-    type t = [
-      | `EmailParse (* TODO: More data *)
-      | Header.Field.Value.Error.t
-    ]
-
-    let message err =
-      match err with
-      | `EmailParse -> "Error parsing the given email"
-      | #Header.Field.Value.Error.t as e ->
-          Header.Field.Value.Error.message e
-  end
-
-  type parsetree  = Netmime.complex_mime_message
-  type error      = Error.t
-
-  (** parse email string into a parse tree *)
-  let parse s =
-    let input = new Netchannels.input_string s in
-    let ch = new Netstream.input_stream input  in
-    let f ch =
-      Netmime_channels.read_mime_message
-        ~multipart_style:`Deep
-        ch                                     in
-    (* TODO: more fine-grained error handling *)
-    Result.trapc
-      `EmailParse
-      (Netchannels.with_in_obj_channel ch)
-      f
-
-  (* see
-     http://projects.camlcity.org/projects/dl/ocamlnet-4.1.9/doc/html-main/Netmime_tut.html
-     -- I /think/ that with_in_obj_channel should close both the Netchannels and
-     the Netstream input bits, but it's worth keeping an eye on. *)
-
-  (** serialize a parsetree into a string *)
-  let to_string tree =
-    let (header, _) = tree in
-    (* defaulting to a megabyte seems like a nice round number *)
-    let n =
-      Exn.default
-        (1024*1024)
-        Netmime_header.get_content_length header
-    in
-    let buf = Stdlib.Buffer.create n in
-    let channel_writer ch =
-      Netmime_channels.write_mime_message
-        ?crlf:(Some false)
-        ch
-        tree
-    in
-    Netchannels.with_out_obj_channel
-      (new Netchannels.output_buffer buf)
-      channel_writer ;
-    Stdlib.Buffer.contents buf
-
-  let timestamp () =
-    Unix.time ()
-      |> string_of_float
-      |> fun x -> String.(sub x 0 (length x - 1))
-
-  (** predicate for email parts that are attachments *)
-  let is_attachment tree =
-    let ( let* ) = Result.(>>=) in
-    let header, _ = tree in
-      match header # field "content-disposition" with
-      | exception Not_found -> Ok false
-      | exception e -> raise e (* TODO: Better logging and error handling *)
-      | hd ->
-          let* hv = Header.Field.Value.parse hd in
-          let s = String.lowercase_ascii (Header.Field.Value.value hv) in
-            Ok (s = "attachment" || s = "inline")
-
-  let is_attach tree =
-    let header, _ = tree in
-      match Header.lookup_value header "content-disposition" with
-      | None -> false
-      | Some cd ->
-          let s = String.lowercase_ascii cd in
-            s = "attachment" || s = "inline"
-
-  let renamed_file id new_ext filename =
-    let base = Filename.remove_extension filename in
-    String.concat ""
-      [ base;
-        "_CONVERTED";
-        id;
-        new_ext;
+module Conversion_ocamlnet = struct
+  module Make (C: ATTACHMENT_CONVERTER) = struct
+    module Error = struct
+      type t = [
+        | `EmailParse (* TODO: More data *)
+        | Header.Field.Value.Error.t
       ]
 
-  let meta_header_name = "X-Attachment-Converter" (* TODO: MOVE SOMEWHERE ELSE, CODE SMELL *)
+      let message err =
+        match err with
+        | `EmailParse -> "Error parsing the given email"
+        | #Header.Field.Value.Error.t as e ->
+            Header.Field.Value.Error.message e
+    end
 
-  let create_meta_header_val src tar ts cid hd : Header.Field.Value.t =
-    let params =
-      [ "source-type", src;
-        "target-type", tar;
-        "time-stamp", ts;
-        "conversion-id", cid;
-        "original-file-hash", hd;
-      ]
-    in
-      Header.Field.Value.hf_value
-        ~params:(map (uncurry Header.Field.Value.Parameter.param) params)
-        "converted"
+    type parsetree  = Netmime.complex_mime_message
+    type error      = Error.t
 
-  let update_header hd src trans_entry hashed_data =
-    let open Header.Field.Value in
-    let open Configuration.Formats in
-    let ( let* ) = Result.(>>=) in
-    let ts = timestamp () in
-    let rename = renamed_file ts trans_entry.target_ext in
-    let update_ct =
-      update_value trans_entry.target_type >>
-      map_val "name" rename
-    in
-    let update_cd =
-      update_value "attachment" >>
-      map_val "filename" rename >>
-      map_val "filename*" rename
-    in
-    let update_cte = update_value "base64" in
-    let update_fields = let open Header in
-      update_or_noop update_ct "Content-Type" >>
-      update_or_default update_cd (hf_value "attachment") "Content-Disposition" >>
-      update_or_noop update_cte "Content-Transfer-Encoding">>
-      add
-        (create_meta_header_val
-          src
-          trans_entry.target_type
-          ts
-          trans_entry.convert_id
-          (string_of_int hashed_data))
-        meta_header_name
-    in
-    let* fields = Header.from_assoc_list (hd # fields) in
-    let process =
-      update_fields >>
-      Header.to_assoc_list >>
-      Netmime.basic_mime_header >>
-      Result.ok
-    in
-      process fields
+    (** parse email string into a parse tree *)
+    let parse s =
+      let input = new Netchannels.input_string s in
+      let ch = new Netstream.input_stream input  in
+      let f ch =
+        Netmime_channels.read_mime_message
+          ~multipart_style:`Deep
+          ch                                     in
+      (* TODO: more fine-grained error handling *)
+      Result.trapc
+        `EmailParse
+        (Netchannels.with_in_obj_channel ch)
+        f
 
-  let transform hd bd src trans_entry =
-    let open Netmime in
-    let open Configuration.Formats in
-    let ( let* ) = Result.(>>=) in
-    let data = bd # value in
-    let hashed_data = Hashtbl.hash data in
-    let* conv_hd = update_header hd src trans_entry hashed_data in
-    let conv_data = C.convert trans_entry.shell_command data in
-      Ok (match trans_entry.variety with
-        | NoChange -> hd, `Body bd
-        | DataOnly -> hd, `Body (memory_mime_body conv_data)
-        | DataAndHeader -> conv_hd, `Body (memory_mime_body conv_data))
+    (* see
+       http://projects.camlcity.org/projects/dl/ocamlnet-4.1.9/doc/html-main/Netmime_tut.html
+       -- I /think/ that with_in_obj_channel should close both the Netchannels and
+       the Netstream input bits, but it's worth keeping an eye on. *)
 
-    (* Notes: Content-Disposition headers provide information about how
-        to present a message or a body part. When a body part is to be
-        treated as an attached file, the Content-Disposition header will
-        include a file name parameter. *)
+    (** serialize a parsetree into a string *)
+    let to_string tree =
+      let (header, _) = tree in
+      (* defaulting to a megabyte seems like a nice round number *)
+      let n =
+        Exn.default
+          (1024*1024)
+          Netmime_header.get_content_length header
+      in
+      let buf = Stdlib.Buffer.create n in
+      let channel_writer ch =
+        Netmime_channels.write_mime_message
+          ?crlf:(Some false)
+          ch
+          tree
+      in
+      Netchannels.with_out_obj_channel
+        (new Netchannels.output_buffer buf)
+        channel_writer ;
+      Stdlib.Buffer.contents buf
 
-  let already_converted tree =
-    let rec build tree =
-      match tree with
-      | header, `Body _ ->
-          let p =
-            let ( let* ) = Option.(>>=) in
-            let* hashed = Header.lookup_param header meta_header_name "original-file-hash" in
-            let* id = Header.lookup_param header meta_header_name "conversion-id" in
-              Some (int_of_string hashed, id)
-          in
-            Option.to_list p
-      | _, `Parts parts ->
-          List.flatmap build parts
-    in
-      build tree
+    let timestamp () =
+      Unix.time ()
+        |> string_of_float
+        |> fun x -> String.(sub x 0 (length x - 1))
 
-  let is_converted tree =
-    let header, _ = tree in
-      Option.something
-        (Header.lookup_value header meta_header_name)
+    let renamed_file id new_ext filename =
+      let base = Filename.remove_extension filename in
+      String.concat ""
+        [ base;
+          "_CONVERTED";
+          id;
+          new_ext;
+        ]
 
-  let filter_converted hashed converted to_convert =
-    let rec process l r =
-      match l with
-      | [] -> r
-      | (h, id) :: hs ->
-          if h = hashed then
-            let _ = write stderr "got here" in
-            process hs (List.filter (fun c -> c.Configuration.Formats.convert_id <> id) r)
-          else
-            process hs r
-    in
-      process converted to_convert
+    let create_meta_header_val
+      ~source_type:src
+      ~target_type:tar
+      ~timestamp:ts
+      ~conv_id:cid
+      ~hashed:hd : Header.Field.Value.t =
+      let params =
+        [ "source-type", src;
+          "target-type", tar;
+          "time-stamp", ts;
+          "conversion-id", cid;
+          "original-file-hash", hd;
+        ]
+      in
+        Header.Field.Value.hf_value
+          ~params:(map (uncurry Header.Field.Value.Parameter.param) params)
+          "converted"
 
-  let body_flatmap (f: parsetree -> parsetree list) tree =
-    let create_multipart_header () = Netmime.basic_mime_header [] (* TODO *) in
-    let list_to_tree (l: parsetree list) =
-      Option.default
-        (create_multipart_header (), `Parts l)
-        (List.head l)
-    in
-    let rec process tree =
-      match tree with
-      | header, `Body body -> list_to_tree (f (header, `Body body))
-      | header, `Parts parts ->
-          let g t =
-            match t with
-            | h, `Body b -> f (h, `Body b)
-            | h, `Parts p -> [process (h, `Parts p)]
-          in
-            (header, `Parts (List.flatmap g parts))
-    in
-      process tree
+    let update_header hd src trans_entry hashed_data =
+      let open Header.Field.Value in
+      let open Configuration.Formats in
+      let ( let* ) = Result.(>>=) in
+      let ts = timestamp () in
+      let rename = renamed_file ts trans_entry.target_ext in
+      let update_ct =
+        update_value trans_entry.target_type >>
+        map_val "name" rename
+      in
+      let update_cd =
+        update_value "attachment" >>
+        map_val "filename" rename >>
+        map_val "filename*" rename
+      in
+      let update_cte = update_value "base64" in
+      let update_fields = let open Header in
+        update_or_noop update_ct "Content-Type" >>
+        update_or_default update_cd (hf_value "attachment") "Content-Disposition" >>
+        update_or_noop update_cte "Content-Transfer-Encoding">>
+        add
+          (create_meta_header_val
+            ~source_type:src
+            ~target_type:trans_entry.target_type
+            ~timestamp:ts
+            ~conv_id:trans_entry.convert_id
+            ~hashed:(string_of_int hashed_data))
+          Constants.meta_header_name
+      in
+      let* fields = Header.from_assoc_list (hd # fields) in
+      let process =
+        update_fields >>
+        Header.to_assoc_list >>
+        Netmime.basic_mime_header >>
+        Result.ok
+      in
+        process fields
 
-  let amap_or_copy dict ?(copy=true) ?(idem=true) tree =
-    let done_converting = if idem then already_converted tree else [] in
-    let converted_attachments tree =
-      match tree with
-      | header, `Body body ->
-          if is_attach (header, `Body body) && (not idem || not (is_converted (header, `Body body))) then
-            match Header.lookup_value header "content-type" with
-            | None -> []
-            | Some ct ->
-               let hashed = Hashtbl.hash (body # value) in (* TODO: pass this to transform *)
-               let conversions = Option.default [] (Configuration.Formats.Dict.find_opt ct dict) in
-               let trans_lst = filter_converted hashed done_converting conversions in
-                 Result.reduce (List.map (transform header body ct) trans_lst) @
-                 if copy || empty trans_lst then [header, `Body body] else []
-          else
-            [header, `Body body]
-      | _, `Parts _ -> [] (* case never reached *)
-    in
-      body_flatmap converted_attachments tree
+    let hash_attach body = Hashtbl.hash (body # value)
 
-(*    let ( let* ) = Result.bind in
-    let rec copy_or_skip lst =
-      match lst with
-      | (bhd, `Body b) :: rs ->
-          let* check = is_attachment (bhd, `Body b) in
-          let* converted =
-            if   check
-            then match bhd # field "content-type" with
-                 | exception Not_found -> Ok [(bhd, `Body b)]
-                 | exception e -> raise e (* TODO: Better logging and error handling *)
-                 | ct ->
-                     let* hv = Header.Field.Value.parse ct in
-                     let src = Header.Field.Value.value hv in
-                     let trans_lst = Option.default []
-                                       (Configuration.Formats.Dict.find_opt src dict)
-                     in
-                       Ok ((Result.reduce (List.map (transform bhd b src) trans_lst)) @
-                         if copy || empty trans_lst then [(bhd, `Body b)] else []) (* TODO: better logging *)
-            else Ok [(bhd, `Body b)]
-          in
-          let* next_lst  = copy_or_skip rs in
-            Ok (converted @ next_lst)
-      | (phd, `Parts p) :: rs ->
-          let* conv_lst = copy_or_skip p in
-          let* next_lst = copy_or_skip rs in
-          Ok ((phd, `Parts conv_lst) :: next_lst)
-      | [] -> Ok []
-    in
-    match tree with
-    | _, `Body _ -> Ok tree (* TODO: Handle case with no body *)
-    | header, `Parts p_lst ->
-        let* cmp_lst = copy_or_skip p_lst in
-        Ok (header, `Parts cmp_lst)
-*)
+    let transform hd bd src trans_entry =
+      let open Netmime in
+      let open Configuration.Formats in
+      let ( let* ) = Result.(>>=) in
+      let data = bd # value in
+      let hashed_data = hash_attach bd in
+      let* conv_hd = update_header hd src trans_entry hashed_data in
+      let conv_data = C.convert trans_entry.shell_command data in
+        Ok (match trans_entry.variety with
+          | NoChange -> hd, `Body bd
+          | DataOnly -> hd, `Body (memory_mime_body conv_data)
+          | DataAndHeader -> conv_hd, `Body (memory_mime_body conv_data))
 
-  (**applies conversions to the attachment elements of the parsetree, replacing the original
+      (* Notes: Content-Disposition headers provide information about how
+          to present a message or a body part. When a body part is to be
+          treated as an attached file, the Content-Disposition header will
+          include a file name parameter. *)
+
+    let already_converted tree =
+      let rec build tree =
+        match tree with
+        | header, `Body _ ->
+            let conv =
+              let ( let* ) = Option.(>>=) in
+              let* hashed = Header.lookup_param header Constants.meta_header_name "original-file-hash" in
+              let* id = Header.lookup_param header Constants.meta_header_name "conversion-id" in
+                Some (int_of_string hashed, id)
+            in
+              Option.to_list conv
+        | _, `Parts parts ->
+            List.flatmap build parts
+      in
+        build tree
+
+    let filter_converted hashed converted to_convert =
+      let rec process l r =
+        match l with
+        | [] -> r
+        | (h, id) :: hs ->
+            if h = hashed then
+              process hs (List.filter (fun c -> c.Configuration.Formats.convert_id <> id) r)
+            else
+              process hs r
+      in
+        process converted to_convert
+
+    let body_flatmap (f: parsetree -> parsetree list) tree =
+      let create_multipart_header () = Netmime.basic_mime_header [] (* TODO *) in
+      let list_to_tree (l: parsetree list) =
+        Option.default
+          (create_multipart_header (), `Parts l)
+          (List.head l)
+      in
+      let rec process tree =
+        match tree with
+        | header, `Body body -> list_to_tree (f (header, `Body body))
+        | header, `Parts parts ->
+            let g t =
+              match t with
+              | h, `Body b -> f (h, `Body b)
+              | h, `Parts p -> [process (h, `Parts p)]
+            in
+              (header, `Parts (List.flatmap g parts))
+      in
+        process tree
+
+    let is_attachment tree =
+      let header, _ = tree in
+        match Header.lookup_value header "content-disposition" with
+        | None -> false
+        | Some cd ->
+            let s = String.lowercase_ascii cd in
+              s = "attachment" || s = "inline"
+
+    let is_converted tree =
+      let header, _ = tree in
+        Option.something
+          (Header.lookup_value header Constants.meta_header_name)
+
+    let amap_or_copy dict ?(copy=true) ?(idem=true) tree =
+      let done_converting = if idem then already_converted tree else [] in
+      let converted_attachments tree =
+        match tree with
+        | header, `Body body ->
+            if is_attachment (header, `Body body) && (not idem || not (is_converted (header, `Body body))) then
+              match Header.lookup_value header "content-type" with
+              | None -> []
+              | Some ct ->
+                 let hashed = hash_attach body in
+                 let conversions = Option.default [] (Configuration.Formats.Dict.find_opt ct dict) in
+                 let trans_lst = filter_converted hashed done_converting conversions in
+                   Result.reduce (List.map (transform header body ct) trans_lst) @
+                   if copy || empty trans_lst then [header, `Body body] else []
+            else
+              [header, `Body body]
+        | _, `Parts _ -> [] (* note: case never reached *)
+      in
+        body_flatmap converted_attachments tree
+
+    (**applies conversions to the attachment elements of the parsetree, replacing the original
+          attachment with the converted versions in the returned parsetree*)
+    let amap dict (tree : parsetree) =
+      amap_or_copy dict ~copy:false tree
+
+    (**applies conversions to the attachment elements of the parsetree, leaving the original
         attachment with the converted versions in the returned parsetree*)
-  let amap dict (tree : parsetree) =
-    amap_or_copy dict ~copy:false tree
+    let acopy dict (tree : parsetree) =
+      amap_or_copy dict tree
 
-  (**applies conversions to the attachment elements of the parsetree, leaving the original
-      attachment with the converted versions in the returned parsetree*)
-  let acopy dict (tree : parsetree) =
-    amap_or_copy dict tree
+    let acopy_email config email =
+      let ( let* ) = Result.bind in
+      let* tree = parse email in
+      let converted_tree = acopy config tree in
+        Ok (to_string converted_tree)
 
-  let acopy_email config email =
-    let ( let* ) = Result.bind in
-    let* tree = parse email in
-    let converted_tree = acopy config tree in
-      Ok (to_string converted_tree)
-
-  let acopy_mbox config in_chan =
-    let converter (fromline, em) =
-      match acopy_email config em with
-      | Ok converted -> fromline ^ "\n" ^ converted
-      | Error _ -> write stderr "Conversion failure\n"; fromline ^ "\n" ^ em (* TODO: better logging *)
-    in
-      Ok (Mbox.convert_mbox in_chan converter)
+    let acopy_mbox config in_chan =
+      let converter (fromline, em) =
+        match acopy_email config em with
+        | Ok converted -> fromline ^ "\n" ^ converted
+        | Error _ -> write stderr "Conversion failure\n"; fromline ^ "\n" ^ em (* TODO: better logging *)
+      in
+        Ok (Mbox.convert_mbox in_chan converter)
+  end
 end
 
-module Conversion_ocamlnet = Conversion_ocamlnet_F (Attach_conv)
-module _ : CONVERT = Conversion_ocamlnet
+module Converter = Conversion_ocamlnet.Make (Attach_conv)
+module _ : CONVERT = Converter

--- a/lib/convert.ml
+++ b/lib/convert.ml
@@ -156,7 +156,7 @@ module Conversion_ocamlnet = struct
       in
         process fields
 
-    let hash_attach body = Hashtbl.hash (body # value)
+    let hash_attach body = Hashtbl.hash (body # value) (* TODO: replace with better hash function *)
 
     let transform hd bd src trans_entry =
       let open Netmime in

--- a/lib/convert.ml
+++ b/lib/convert.ml
@@ -133,7 +133,7 @@ module Conversion_ocamlnet = struct
         map_val "filename" rename >>
         map_val "filename*" rename
       in
-      let update_cte = update_value "base64" in
+      let update_cte = update_value Constants.meta_header_cont_dist in
       let update_fields = let open Header in
         update_or_noop update_ct "Content-Type" >>
         update_or_default update_cd (hf_value "attachment") "Content-Disposition" >>

--- a/lib/dune
+++ b/lib/dune
@@ -5,7 +5,7 @@
 (library
  (name lib)
  (libraries prelude mrmime threads netstring unix re)
- (modules lib configuration errorHandling report convert mbox header))
+ (modules lib configuration errorHandling report convert mbox header utils))
 
 (env
   (dev                                  ; make warnings non-fatal

--- a/lib/dune
+++ b/lib/dune
@@ -5,7 +5,7 @@
 (library
  (name lib)
  (libraries prelude mrmime threads netstring unix re)
- (modules lib configuration errorHandling report convert mbox))
+ (modules lib configuration errorHandling report convert mbox header))
 
 (env
   (dev                                  ; make warnings non-fatal

--- a/lib/errorHandling.ml
+++ b/lib/errorHandling.ml
@@ -20,23 +20,23 @@ module _ : ERROR with
   type t = [
     | `EmailParse
     | Header.Field.Value.Error.t
-  ] = Convert.Conversion_ocamlnet.Error
+  ] = Convert.Converter.Error
 
 module Error : ERROR with
   type t = [
-    | Convert.Conversion_ocamlnet.Error.t
+    | Convert.Converter.Error.t
     | Configuration.ParseConfig.Error.t
   ]
   = struct
   type t = [
-    | Convert.Conversion_ocamlnet.Error.t
+    | Convert.Converter.Error.t
     | Configuration.ParseConfig.Error.t
   ]
 
   let message err =
     match err with
-    | #Convert.Conversion_ocamlnet.Error.t as e ->
-        Convert.Conversion_ocamlnet.Error.message e
+    | #Convert.Converter.Error.t as e ->
+        Convert.Converter.Error.message e
     | #Configuration.ParseConfig.Error.t as e ->
         Configuration.ParseConfig.Error.message e
 end

--- a/lib/errorHandling.ml
+++ b/lib/errorHandling.ml
@@ -14,13 +14,13 @@ module _ : ERROR with
 module _ : ERROR with
   type t = [
     | `ParameterParse
-  ] = Convert.Conversion_ocamlnet.HeaderValue.Error
+  ] = Header.Field.Value.Error
 
 module _ : ERROR with
   type t = [
     | `EmailParse
     | `MissingContentType
-    | Convert.Conversion_ocamlnet.HeaderValue.Error.t
+    | Header.Field.Value.Error.t
   ] = Convert.Conversion_ocamlnet.Error
 
 module Error : ERROR with

--- a/lib/errorHandling.ml
+++ b/lib/errorHandling.ml
@@ -19,7 +19,6 @@ module _ : ERROR with
 module _ : ERROR with
   type t = [
     | `EmailParse
-    | `MissingContentType
     | Header.Field.Value.Error.t
   ] = Convert.Conversion_ocamlnet.Error
 

--- a/lib/errorHandling.ml
+++ b/lib/errorHandling.ml
@@ -19,6 +19,7 @@ module _ : ERROR with
 module _ : ERROR with
   type t = [
     | `EmailParse
+    | `MissingContentType
     | Convert.Conversion_ocamlnet.HeaderValue.Error.t
   ] = Convert.Conversion_ocamlnet.Error
 

--- a/lib/header.ml
+++ b/lib/header.ml
@@ -180,13 +180,22 @@ let update g name fields =
 
 let update_or_noop f = update (Option.map f)
 let update_or_default f def = update (Option.either (f >> Option.some) (Some def))
-let add new_v = update (k (Some new_v))
+let add new_v = update (k (Some new_v)) (* note: replaces the old conversion *)
 
 let lookup_param header field_name param_name =
-    let ( let* ) = Option.(>>=) in
-      match header # field field_name with
-      | exception Not_found -> None
-      | exception e -> raise e
-      | hv_str ->
-          let* hv = Result.to_option (Field.Value.parse hv_str) in
-            Field.Value.lookup_param param_name hv
+  let ( let* ) = Option.(>>=) in
+    match header # field field_name with
+    | exception Not_found -> None
+    | exception e -> raise e
+    | hv_str ->
+        let* hv = Result.to_option (Field.Value.parse hv_str) in
+          Field.Value.lookup_param param_name hv
+
+let lookup_value header field_name =
+  let ( let* ) = Option.(>>=) in
+    match header # field field_name with
+    | exception Not_found -> None
+    | exception e -> raise e
+    | hv_str ->
+        let* hv = Result.to_option (Field.Value.parse hv_str) in
+          Some (Field.Value.value hv)

--- a/lib/header.ml
+++ b/lib/header.ml
@@ -1,0 +1,183 @@
+open Prelude
+
+module Field = struct
+
+  module Value = struct
+    module Error = struct
+      type t = [
+        | `ParameterParse
+      ]
+
+      let message _ = "Error reading parameters" (* TODO: more data *)
+    end
+
+    module Parameter = struct
+      type t = {
+        attr: string;
+        value: string;
+        quotes: bool;
+      }
+
+      let map_attr f p = { p with attr = f p.attr }
+      let map_val f p = { p with value = f p.value }
+      let map_qt f p = { p with quotes = f p.quotes }
+
+      let attr p = p.attr
+      let value p = p.value
+      let quotes p = p.quotes
+
+      let param ?(quotes=false) attr value =
+        { attr = attr;
+          value = value;
+          quotes = quotes;
+        }
+
+      let is_quoted str = String.prefix "\"" str && String.suffix "\"" str
+      let unquoted str = String.trim "\"" str
+      let quoted str = "\"" ^ str ^ "\""
+
+      let parse str =
+        let cut_or_none str = match String.cut ~sep:"=" str with
+          | left, Some right -> Some (left, right)
+          | _, None -> None
+        in
+        let ( let* ) = Option.(>>=) in
+        let* (attr, value) = cut_or_none str in
+          Some (
+            if is_quoted value then
+              param ~quotes:true attr (unquoted value)
+            else
+              param attr value
+          )
+
+      let to_string { attr; value; quotes } =
+        attr ^ "=" ^ (if quotes then quoted value else value)
+    end
+
+    type t = {
+      value: string;
+      params: Parameter.t list;
+    }
+
+    let value hv = hv.value
+    let params hv = hv.params
+
+    let hf_value ?(params=[]) value =
+      { value = value;
+        params = params;
+      }
+
+    let parse str =
+      let vs = String.cuts ~sep:";" str in
+      let vs = List.map String.(trim whitespace) vs in (* not sure if trimming is necessary or should be done *)
+      let rec process ls =
+        match ls with
+        | [] -> Some []
+        | None :: _ -> None
+        | Some p :: ps -> Option.map (fun xs -> p :: xs) (process ps)
+      in
+        match vs with
+        | [] -> Error `ParameterParse
+        | value :: params ->
+            match process (List.map Parameter.parse params) with
+            | None -> Error `ParameterParse
+            | Some params ->
+                Ok (hf_value ~params:params value)
+
+    let unsafe_parse = Result.get_ok << parse
+
+    let to_string { value ; params } =
+      let f curr p = curr ^ ";\n\t" ^ Parameter.to_string p in
+        match params with
+        | [] -> value
+        | _  -> List.foldl f value params
+
+    let lookup_param attr hv =
+      let rec lookup attr ls =
+        match ls with
+        | [] -> None
+        | p :: ps ->
+            if Parameter.attr p = attr then
+              Some (Parameter.value p)
+            else
+              lookup attr ps
+      in
+        lookup attr (params hv)
+
+    let update_value new_value hv =
+      { hv with value = new_value }
+
+    let update_param attr f hv =
+      let cons_op x ls = Option.either (List.snoc ls) ls x in
+      let rec update ls =
+        match ls with
+        | [] -> cons_op (f None) []
+        | p :: ps ->
+            if Parameter.attr p = attr then
+              cons_op (f (Some p)) ps
+            else
+              p :: update ps
+      in
+        { hv with params = update hv.params }
+
+    let map_val attr f =
+      update_param attr (Option.map (Parameter.map_val f))
+
+    let replace_val attr new_value =
+      map_val attr (k new_value)
+
+    let remove_val attr =
+      update_param attr (k None)
+
+    let add_param ?(quotes=false) attr value =
+      update_param attr
+        (k (Some (Parameter.param ~quotes:quotes attr value)))
+  end
+
+  type t = {
+    name : string;
+    value : Value.t;
+  }
+
+  let name fld = fld.name
+  let value fld = fld.value
+
+  let h_field name value = { name = name; value = value }
+
+  let h_field_from_str name value_str : (t, Value.Error.t) result =
+    let ( let* ) = Result.(>>=) in
+    let* value = Value.parse value_str in
+      Ok (h_field name value)
+
+  let to_assoc { name; value } =
+    (name, Value.to_string value)
+
+end
+
+let from_assoc_list ls : (Field.t list, Field.Value.Error.t) result =
+  let ( let* ) = Result.(>>=) in
+  let f (n, v) curr =
+    let* l = Field.h_field_from_str n v in
+    let* r = curr in
+      Ok (l :: r)
+  in
+    List.foldr f (Ok []) ls
+
+let to_assoc_list ls : (string * string) list = List.map Field.to_assoc ls
+
+let update g name fields =
+  let cons_op key x ls = Option.either (fun y -> (Field.h_field key y :: ls)) ls x in
+  let rec process ls =
+    match ls with
+    | [] -> cons_op name (g None) []
+    | fld :: fs ->
+        if Field.name fld = name then
+          cons_op (Field.name fld) (g (Some (Field.value fld))) fs
+        else
+          fld :: process fs
+  in
+    process fields
+
+let update_or_noop f = update (Option.map f)
+let update_or_default f def = update (Option.either (f >> Option.some) (Some def))
+let add new_v = update (k (Some new_v))

--- a/lib/header.ml
+++ b/lib/header.ml
@@ -181,3 +181,12 @@ let update g name fields =
 let update_or_noop f = update (Option.map f)
 let update_or_default f def = update (Option.either (f >> Option.some) (Some def))
 let add new_v = update (k (Some new_v))
+
+let lookup_param header field_name param_name =
+    let ( let* ) = Option.(>>=) in
+      match header # field field_name with
+      | exception Not_found -> None
+      | exception e -> raise e
+      | hv_str ->
+          let* hv = Result.to_option (Field.Value.parse hv_str) in
+            Field.Value.lookup_param param_name hv

--- a/lib/lib.ml
+++ b/lib/lib.ml
@@ -9,6 +9,7 @@ module Report        = Report
 module Mbox          = Mbox
 module Convert       = Convert
 module ErrorHandling = ErrorHandling
+module Header        = Header
 
 (*
  * Copyright (c) 2021 Matt Teichman

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -1,0 +1,4 @@
+module Constants = struct
+  let meta_header_name = "X-Attachment-Converter"
+  let meta_header_cont_dist = "base64"
+end

--- a/main.ml
+++ b/main.ml
@@ -7,11 +7,29 @@
  *)
 
 open Prelude
+open Cmdliner
 
-let report ?(params=false) () =
+type cmd_input = [`Stdin | `File of string]
+type cmd_input_parser = string -> (cmd_input, [`Msg of string]) Stdlib.result
+type cmd_input_printer = cmd_input Arg.printer
+
+let cmd_input_parser str = 
+  if Sys.file_exists str 
+  then Ok (`File str)
+  else Error (`Msg ("File: " ^ str ^ " does not exist."))
+
+let cmd_input_printer fmt input = let str = 
+  match input with
+    | `Stdin -> "STDIN"
+    | `File fn -> fn
+  in Format.pp_print_string fmt str
+
+let cmd_input_conv = Arg.conv (cmd_input_parser, cmd_input_printer)
+
+let report ?(params=false) ic =
   let open Lib.Report in
   let module M = Map.Make(String) in
-  let types = content_types ~params:params stdin in
+  let types = content_types ~params:params ic in
     print "Content Types:";
     M.iter
       (fun k v -> print ("  " ^ k ^ " : " ^ (Int.to_string v)))
@@ -19,8 +37,8 @@ let report ?(params=false) () =
 
 let default_config_name = ".config"
 
-let convert ?(single_email=false) () =
-  let open Lib.Convert.Converter in
+ let convert ?(single_email=false) ic =
+   let open Lib.Convert.Conversion_ocamlnet in
   let open Lib.Configuration.ParseConfig in
   let open Lib.ErrorHandling in
   let ( let* ) = Result.(>>=) in
@@ -30,10 +48,10 @@ let convert ?(single_email=false) () =
         let* config = parse_config_file default_config_name in
           if single_email
           then
-            let* converted = acopy_email config (read stdin) in
+             let* converted = acopy_email config (read ic) in
               Ok (write stdout converted)
           else
-            acopy_mbox config stdin
+             acopy_mbox config ic
       in
         match processed with
         | Error err -> write stderr (Error.message err) (* TODO: better error handling *)
@@ -44,15 +62,38 @@ let convert ?(single_email=false) () =
           "Error: missing config file '%s'\n"
           default_config_name)
 
-(* A _very_ minimal executable *)
-let main = if   Array.length Sys.argv > 1
-           then match Sys.argv.(1) with
-                | "--report" -> report ()
-                | "--report-params" -> report ~params:true ()
-                | "--single-email" -> convert ~single_email:true ()
-                | unknown_flag -> write stderr ("unknown flag: " ^ unknown_flag)
-           else convert ()
+ let convert_wrapper sem rpt rpt_p inp =
+   let report_or_convert ic = 
+     if rpt_p then report ~params:true ic
+     else if rpt then report ic
+     else convert sem ic in
+   match inp with 
+     | `File fn -> within (report_or_convert) fn
+     | `Stdin -> report_or_convert stdin
+ 
+ let input_t = let doc = "Input file to be converted." in
+ Arg.(value & pos 0 cmd_input_conv `Stdin & info [] ~doc)
+ 
+ let report_params_t = let doc = "Prints a list of all MIME types in the input along with 
+ all header and field parameters that go with it." in
+ Arg.(value & flag & info ["report-params"] ~doc)
+ 
+ let report_t = let doc = "Provides a list of all attachment types in a given mailbox." in
+ Arg.(value & flag & info ["r"; "report"] ~doc)
+ 
+ let single_email_t = let doc = "Converts email attachments assuming the input is a single plain text email." in
+ Arg.(value & flag & info ["single-email"] ~doc)
+ 
+ let convert_t = Term.(const convert_wrapper $ single_email_t $ report_t $ report_params_t $ input_t)
+ 
+ let cmd = let doc = "Converts email attachments." in
+   let info = Cmd.info "attachment-converter" ~doc in
+   Cmd.v info convert_t
+ 
+ let main () = exit (Cmd.eval cmd)
 
+ let () = main ()
+ 
 (*
  * Copyright (c) 2021 Matt Teichman
  *

--- a/main.ml
+++ b/main.ml
@@ -7,29 +7,11 @@
  *)
 
 open Prelude
-open Cmdliner
 
-type cmd_input = [`Stdin | `File of string]
-type cmd_input_parser = string -> (cmd_input, [`Msg of string]) Stdlib.result
-type cmd_input_printer = cmd_input Arg.printer
-
-let cmd_input_parser str = 
-  if Sys.file_exists str 
-  then Ok (`File str)
-  else Error (`Msg ("File: " ^ str ^ " does not exist."))
-
-let cmd_input_printer fmt input = let str = 
-  match input with
-    | `Stdin -> "STDIN"
-    | `File fn -> fn
-  in Format.pp_print_string fmt str
-
-let cmd_input_conv = Arg.conv (cmd_input_parser, cmd_input_printer)
-
-let report ?(params=false) ic =
+let report ?(params=false) () =
   let open Lib.Report in
   let module M = Map.Make(String) in
-  let types = content_types ~params:params ic in
+  let types = content_types ~params:params stdin in
     print "Content Types:";
     M.iter
       (fun k v -> print ("  " ^ k ^ " : " ^ (Int.to_string v)))
@@ -37,8 +19,8 @@ let report ?(params=false) ic =
 
 let default_config_name = ".config"
 
- let convert ?(single_email=false) ic =
-   let open Lib.Convert.Conversion_ocamlnet in
+let convert ?(single_email=false) () =
+  let open Lib.Convert.Converter in
   let open Lib.Configuration.ParseConfig in
   let open Lib.ErrorHandling in
   let ( let* ) = Result.(>>=) in
@@ -48,10 +30,10 @@ let default_config_name = ".config"
         let* config = parse_config_file default_config_name in
           if single_email
           then
-             let* converted = acopy_email config (read ic) in
+            let* converted = acopy_email config (read stdin) in
               Ok (write stdout converted)
           else
-             acopy_mbox config ic
+            acopy_mbox config stdin
       in
         match processed with
         | Error err -> write stderr (Error.message err) (* TODO: better error handling *)
@@ -62,38 +44,15 @@ let default_config_name = ".config"
           "Error: missing config file '%s'\n"
           default_config_name)
 
- let convert_wrapper sem rpt rpt_p inp =
-   let report_or_convert ic = 
-     if rpt_p then report ~params:true ic
-     else if rpt then report ic
-     else convert sem ic in
-   match inp with 
-     | `File fn -> within (report_or_convert) fn
-     | `Stdin -> report_or_convert stdin
- 
- let input_t = let doc = "Input file to be converted." in
- Arg.(value & pos 0 cmd_input_conv `Stdin & info [] ~doc)
- 
- let report_params_t = let doc = "Prints a list of all MIME types in the input along with 
- all header and field parameters that go with it." in
- Arg.(value & flag & info ["report-params"] ~doc)
- 
- let report_t = let doc = "Provides a list of all attachment types in a given mailbox." in
- Arg.(value & flag & info ["r"; "report"] ~doc)
- 
- let single_email_t = let doc = "Converts email attachments assuming the input is a single plain text email." in
- Arg.(value & flag & info ["single-email"] ~doc)
- 
- let convert_t = Term.(const convert_wrapper $ single_email_t $ report_t $ report_params_t $ input_t)
- 
- let cmd = let doc = "Converts email attachments." in
-   let info = Cmd.info "attachment-converter" ~doc in
-   Cmd.v info convert_t
- 
- let main () = exit (Cmd.eval cmd)
+(* A _very_ minimal executable *)
+let main = if   Array.length Sys.argv > 1
+           then match Sys.argv.(1) with
+                | "--report" -> report ()
+                | "--report-params" -> report ~params:true ()
+                | "--single-email" -> convert ~single_email:true ()
+                | unknown_flag -> write stderr ("unknown flag: " ^ unknown_flag)
+           else convert ()
 
- let () = main ()
- 
 (*
  * Copyright (c) 2021 Matt Teichman
  *

--- a/main.ml
+++ b/main.ml
@@ -20,7 +20,7 @@ let report ?(params=false) () =
 let default_config_name = ".config"
 
 let convert ?(single_email=false) () =
-  let open Lib.Convert.Conversion_ocamlnet in
+  let open Lib.Convert.Converter in
   let open Lib.Configuration.ParseConfig in
   let open Lib.ErrorHandling in
   let ( let* ) = Result.(>>=) in

--- a/tests/convert_tests.ml
+++ b/tests/convert_tests.ml
@@ -1,5 +1,5 @@
 open OUnit2
-open Lib.Convert.Conversion_ocamlnet
+open Lib.Convert.Converter
 open Prelude
 open Lib.Header
 
@@ -71,20 +71,12 @@ let header_value_parser_tests =
       update_test_2 ;
     ]
 
-(* let empty_config_test_0 tree =
-  let description = "empty config is okay on email"     in
-  let open Lib.Configuration.Formats                    in
-  let is_okay     = Result.good (acopy Dict.empty tree) in
-  let check _     = assert_bool "is okay" is_okay       in
-  description >:: check
-
 let empty_config_test_1 tree =
-  let description = "empty config is noop"        in
-  let open Lib.Configuration.Formats              in
-  let copied      = acopy Dict.empty tree         in
-  let check _     = assert_equal (Ok tree) copied in
+  let description = "empty config is noop"   in
+  let open Lib.Configuration.Formats         in
+  let copied      = acopy Dict.empty tree    in
+  let check _     = assert_equal tree copied in
   description >:: check
-*)
 
 let noop_gif_config =
   let open Lib.Configuration.Formats in
@@ -183,8 +175,7 @@ let basic_test_email fname =
   let email = readfile fname in
   "basic test suite for email: " ^ fname >:::
     [ parse_okay email                                     ;
-(*      empty_config_test_0    (Result.get_ok (parse email)) ;
-      empty_config_test_1    (Result.get_ok (parse email)) ; *)
+      empty_config_test_1    (Result.get_ok (parse email)) ;
       noop_gif_config_test_0 (Result.get_ok (parse email)) ;
     ]
 

--- a/tests/convert_tests.ml
+++ b/tests/convert_tests.ml
@@ -71,7 +71,7 @@ let header_value_parser_tests =
       update_test_2 ;
     ]
 
-let empty_config_test_0 tree =
+(* let empty_config_test_0 tree =
   let description = "empty config is okay on email"     in
   let open Lib.Configuration.Formats                    in
   let is_okay     = Result.good (acopy Dict.empty tree) in
@@ -84,6 +84,7 @@ let empty_config_test_1 tree =
   let copied      = acopy Dict.empty tree         in
   let check _     = assert_equal (Ok tree) copied in
   description >:: check
+*)
 
 let noop_gif_config =
   let open Lib.Configuration.Formats in
@@ -158,8 +159,7 @@ let noop_gif_config_test_0 tree =
   let description = "noop config is noop" in
   let check _ = assert_equal_trees
     tree
-    (Result.get_ok
-      (amap noop_gif_config tree))
+      (amap noop_gif_config tree)
   in
   description >:: check
 
@@ -167,8 +167,7 @@ let header_change_gif_config_test_0 tree =
   let description = "header change config is not noop" in
   let check _ = assert_equal_trees
     tree
-    (Result.get_ok
-      (amap header_change_gif_config tree))
+      (amap header_change_gif_config tree)
   in
   description >:: check
 
@@ -184,8 +183,8 @@ let basic_test_email fname =
   let email = readfile fname in
   "basic test suite for email: " ^ fname >:::
     [ parse_okay email                                     ;
-      empty_config_test_0    (Result.get_ok (parse email)) ;
-      empty_config_test_1    (Result.get_ok (parse email)) ;
+(*      empty_config_test_0    (Result.get_ok (parse email)) ;
+      empty_config_test_1    (Result.get_ok (parse email)) ; *)
       noop_gif_config_test_0 (Result.get_ok (parse email)) ;
     ]
 

--- a/tests/convert_tests.ml
+++ b/tests/convert_tests.ml
@@ -1,6 +1,7 @@
 open OUnit2
 open Lib.Convert.Conversion_ocamlnet
 open Prelude
+open Lib.Header
 
 let basic_cont_dis =
 "attachment;    filename*=utf-8''test.gif;    filename=\"test.gif\""
@@ -21,44 +22,44 @@ let basic_cont_dis_conv_3 =
 "attachment;    filename=\"test_CONVERTED.tiff\";    filename*=utf-8''test_CONVERTED.tiff"
 
 let parse_test_1 =
-  let open HeaderValue in
+  let open Field.Value in
   let description = "parsing basic_cont_dis" in
-  let param1 : HeaderValue.Parameter.t = { attr = "filename*"; value = "utf-8''test.gif"; quotes = false } in
-  let param2 : HeaderValue.Parameter.t = { attr = "filename"; value = "test.gif"; quotes = true } in
-  let out = Ok { head = "attachment"; params = [param1 ; param2 ] } in
+  let param1 : Field.Value.Parameter.t = { attr = "filename*"; value = "utf-8''test.gif"; quotes = false } in
+  let param2 : Field.Value.Parameter.t = { attr = "filename"; value = "test.gif"; quotes = true } in
+  let out = Ok { value = "attachment"; params = [param1 ; param2 ] } in
   let check _ = assert_equal out (parse basic_cont_dis) in
     description >:: check
 
 let to_string_test_1 =
-  let open HeaderValue in
+  let open Field.Value in
   let description = "simple to_string of basic_cont_dis test" in
   let out = "attachment;\n\tfilename*=utf-8''test.gif;\n\tfilename=\"test.gif\"" in
   let check _ = assert_equal out (to_string (Result.get_ok (parse basic_cont_dis))) ~printer:id in
     description >:: check
 
 let to_string_test_2 =
-  let open HeaderValue in
+  let open Field.Value in
   let description = "simple to_string without params" in
-  let out = "attachment;" in
+  let out = "attachment" in
   let check _ = assert_equal out (to_string (Result.get_ok (parse "attachment"))) ~printer:id in
     description >:: check
 
 let update_test_1 =
-  let open HeaderValue in
+  let open Field.Value in
   let description = "simple replace_val test" in
-  let param1: HeaderValue.Parameter.t = { attr = "filename*"; value = "TESTING"; quotes = false } in
-  let param2: HeaderValue.Parameter.t = { attr = "filename"; value = "test.gif"; quotes = true } in
-  let out = { head = "attachment"; params = [param1 ; param2 ] } in
+  let param1: Field.Value.Parameter.t = { attr = "filename*"; value = "TESTING"; quotes = false } in
+  let param2: Field.Value.Parameter.t = { attr = "filename"; value = "test.gif"; quotes = true } in
+  let out = { value = "attachment"; params = [param1 ; param2 ] } in
   let check _ = assert_equal out (replace_val "filename*" "TESTING" (Result.get_ok (parse basic_cont_dis))) in
     description >:: check
 
 let update_test_2 =
-  let open HeaderValue in
-  let description = "simple update_head test" in
-  let param1: HeaderValue.Parameter.t = { attr = "filename*"; value = "utf-8''test.gif"; quotes = false } in
-  let param2: HeaderValue.Parameter.t = { attr = "filename"; value = "test.gif"; quotes = true } in
-  let out = { head = "inline"; params = [param1 ; param2 ] } in
-  let check _ = assert_equal out (update_head "inline" (Result.get_ok (parse basic_cont_dis))) in
+  let open Field.Value in
+  let description = "simple update_value test" in
+  let param1: Field.Value.Parameter.t = { attr = "filename*"; value = "utf-8''test.gif"; quotes = false } in
+  let param2: Field.Value.Parameter.t = { attr = "filename"; value = "test.gif"; quotes = true } in
+  let out = { value = "inline"; params = [param1 ; param2 ] } in
+  let check _ = assert_equal out (update_value "inline" (Result.get_ok (parse basic_cont_dis))) in
     description >:: check
 
 let header_value_parser_tests =


### PR DESCRIPTION
I'm a tad booked today, so I'm going to create a pull request despite the non-automatic merge. This also includes the idempotency code, and a bit of slight reorganizing. Hopefully the merge isn't too bad.

The main thing to note is that I am still using a the `Hashtbl` hash function, which we could replace with something better.