### PR TITLE
66 config file

### DIFF
--- a/lib/configuration.ml
+++ b/lib/configuration.ml
@@ -9,13 +9,9 @@ module Formats = struct
       convert_id    : string;
     }
 
-  module Dict = Map.Make (String)
+    module Dict = Map.Make (String)
 
   type t = (transform_data list) Dict.t
-
-  let conversions d ct =
-    Option.default []
-      (Dict.find_opt ct d)
 
   let mime_type_to_extension mt =
     match mt with
@@ -24,6 +20,20 @@ module Formats = struct
     | "text/tab-separated-values" -> ".tsv"
     | "image/tiff"                -> ".tif"
     | _ -> "" (* TODO: default to no extension should be logged *)
+
+  let make =
+    let make_t (ty, cm, id) =
+      { target_type = ty
+      ; target_ext = mime_type_to_extension ty
+      ; shell_command = cm
+      ; convert_id = id
+      }
+    in
+    Dict.of_list Dict.empty << List.map (Pair.onright (List.map make_t))
+
+  let conversions d ct =
+    Option.default []
+      (Dict.find_opt ct d)
  end
 
 module ParseConfig = struct
@@ -125,15 +135,42 @@ module ParseConfig = struct
   let parse_config_file = Prelude.readfile >> parse
 end
 
-  let default_config () = assert false (* TODO: Fix This *)
+let default_config () =
+  let open Formats in
+  let script_dir = File.squiggle "~/.config/attachment-converter/scripts/" in
+  make
+  [ "application/pdf" ,
+    [ "application/pdf" , script_dir ^ "soffice-wrapper.sh -i pdf -o pdf" , "soffice-pdf-to-pdfa"
+    ; "text/plain" , script_dir ^ "pdftotext-wrapper.sh" , "pdftotext-pdf-to-text"
+    ]
+  ; "application/msword" ,
+    [ "application/pdf" , script_dir ^ "soffice-wrapper.sh -i doc -o pdf" , "soffice-doc-to-pdfa"
+    ; "text/plain" , script_dir ^ "soffice-wrapper.sh -i doc -o pdf" , "soffice-doc-to-txt"
+    ]
+  ; "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ,
+    [ "application/pdf" , script_dir ^ "soffice-wrapper.sh -i docx -o pdf" , "soffice-docx-to-pdfa"
+    ; "text/plain" , script_dir ^ "pandoc-wrapper.sh -i docx -o txt" , "pandoc-docx-to-txt"
+    ]
+  ; "application/vnd.ms-excel" ,
+    [ "text/tab-separated-values" , script_dir ^ "soffice-wrapper.sh -i xls -o tsv" , "soffice-xls-to-tsv" ]
+  ; "image/gif" ,
+    [ "image/tiff" , script_dir ^ "vips-wrapper.sh -i gif -o tif" , "vips-gif-to-tif" ]
+  ;  "image/bmp" ,
+    [ "image/tiff" , script_dir ^ "vips-wrapper.sh -i bmp -o tif" , "vips-bmp-to-tif" ]
+  ;  "image/jpeg" ,
+    [ "image/tiff" , script_dir ^ "vips-wrapper.sh -i bmp -o tif" , "vips-jpeg-to-tif" ]
+  ]
 
-  let get_config config_files =
-    let open ParseConfig in
-    let config_files =
-      config_files @
-      Option.to_list (Sys.getenv_opt "AC_CONFIG") @
-      [ "~/.config/attachment-converter/acrc" ; "~/.acrc" ]
-    in
-    let config_opt = config_files |> List.dropwhile (not << Sys.file_exists << File.squiggle) |> List.head in
-    let config_str = Option.(default (default_config ()) (map readfile config_opt)) in
-    parse config_str
+let get_config config_files =
+  let open ParseConfig in
+  let config_files =
+    config_files @
+    Option.to_list (Sys.getenv_opt "AC_CONFIG") @
+    [ ~~ "~/.config/attachment-converter/acrc" ; ~~ "~/.acrc" ]
+  in
+  let config_opt =
+    config_files
+    |> List.dropwhile (not << Sys.file_exists)
+    |> List.head
+  in
+  Option.(default (Ok (default_config ())) (map (readfile >> parse) config_opt))

--- a/lib/configuration.ml
+++ b/lib/configuration.ml
@@ -123,4 +123,15 @@ module ParseConfig = struct
       (Refer.of_string config_str)
 
   let parse_config_file = Prelude.readfile >> parse
+
+  let default_config () = assert false (* TODO: FIX THIS SOON! *)
+
+  let get_config config_files =
+    let config_files =
+      config_files @
+      Option.to_list (Sys.getenv_opt "AC_CONFIG") @
+      [ "~/.config/attachment-converter/acrc" ; "~/.acrc" ]
+    in
+    let config_file = List.(head << dropwhile (not << Sys.file_exists << File.squiggle)) config_files in
+    Option.(default (default_config ()) (config_file >>| readfile >>= (parse >> Result.to_option)))
 end

--- a/lib/configuration.ml
+++ b/lib/configuration.ml
@@ -125,27 +125,15 @@ module ParseConfig = struct
   let parse_config_file = Prelude.readfile >> parse
 end
 
-  module Error = struct
-    type t = [
-      `NoConfig
-    ]
-
-    let message err =
-      match err with
-      | `NoConfig -> "No configuration file found."
-  end
-
-  let default_config () = Error `NoConfig
+  let default_config () = assert false (* TODO: Fix This *)
 
   let get_config config_files =
     let open ParseConfig in
-    let open Option in
     let config_files =
       config_files @
-      to_list (Sys.getenv_opt "AC_CONFIG") @
+      Option.to_list (Sys.getenv_opt "AC_CONFIG") @
       [ "~/.config/attachment-converter/acrc" ; "~/.acrc" ]
     in
-    let config_file = config_files |> List.dropwhile (not << Sys.file_exists << File.squiggle) |> List.head in
-    let config = config_file >>| readfile >>= (parse >> Result.to_option) >>| Result.ok in
-    default (default_config ()) config
-
+    let config_opt = config_files |> List.dropwhile (not << Sys.file_exists << File.squiggle) |> List.head in
+    let config_str = Option.(default (default_config ()) (map readfile config_opt)) in
+    parse config_str

--- a/lib/errorHandling.ml
+++ b/lib/errorHandling.ml
@@ -3,18 +3,15 @@ open Utils
 module _ : ERROR = Configuration.ParseConfig.Error
 module _ : ERROR = Header.Field.Value.Error
 module _ : ERROR = Convert.Converter.Error
-module _ : ERROR = Configuration.Error
 
 module Error : ERROR with
   type t = [
     | Convert.Converter.Error.t
     | Configuration.ParseConfig.Error.t
-    | Configuration.Error.t
   ] = struct
   type t = [
     | Convert.Converter.Error.t
     | Configuration.ParseConfig.Error.t
-    | Configuration.Error.t
   ]
 
   let message err =
@@ -23,8 +20,6 @@ module Error : ERROR with
         Convert.Converter.Error.message e
     | #Configuration.ParseConfig.Error.t as e ->
         Configuration.ParseConfig.Error.message e
-    | #Configuration.Error.t as e ->
-        Configuration.Error.message e
 end
 
 module Printer = struct

--- a/lib/errorHandling.ml
+++ b/lib/errorHandling.ml
@@ -3,15 +3,18 @@ open Utils
 module _ : ERROR = Configuration.ParseConfig.Error
 module _ : ERROR = Header.Field.Value.Error
 module _ : ERROR = Convert.Converter.Error
+module _ : ERROR = Configuration.Error
 
 module Error : ERROR with
   type t = [
     | Convert.Converter.Error.t
     | Configuration.ParseConfig.Error.t
+    | Configuration.Error.t
   ] = struct
   type t = [
     | Convert.Converter.Error.t
     | Configuration.ParseConfig.Error.t
+    | Configuration.Error.t
   ]
 
   let message err =
@@ -20,6 +23,8 @@ module Error : ERROR with
         Convert.Converter.Error.message e
     | #Configuration.ParseConfig.Error.t as e ->
         Configuration.ParseConfig.Error.message e
+    | #Configuration.Error.t as e ->
+        Configuration.Error.message e
 end
 
 module Printer = struct

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -40,7 +40,7 @@ let rename_file id new_ext filename =
         else ""
       in
       let msg = String.concat ""
-        [ "converting " ;
+        [ "Converting " ;
           filename ;
           " to "   ;
           new_filename ;

--- a/main.ml
+++ b/main.ml
@@ -41,37 +41,28 @@ let report ?(params=false) ic =
       (fun k v -> print ("  " ^ k ^ " : " ^ (Int.to_string v)))
       types
 
-let default_config_name = ".config"
-
 let convert config_files ?(single_email=false) ic =
   let open Lib.Convert.Converter in
-  let open Lib.Configuration.ParseConfig in
+  let open Lib.Configuration in
   let open Lib.ErrorHandling in
   let open Lib.Mbox.Copier in
   let ( let* ) = Result.(>>=) in
-    if Sys.file_exists default_config_name
-    then
-      let processed =
-        let config = get_config config_files in
-          if single_email
-          then
-            let module DP = Data.Printer in
-            let* converted = acopy_email config (read ic) in
-            let print_both = begin
-                DP.print converted ;
-              end
-            in Ok print_both
-          else
-            acopy_mbox config ic
-      in
-        match processed with
-        | Error err -> write stderr (Error.message err) (* TODO: better error handling *)
-        | Ok _ -> ()
-    else
-      let open Printer in
-      print (Printf.sprintf
-              "Error: missing config file '%s'\n"
-              default_config_name)
+    let processed =
+      let* config = get_config config_files in
+        if single_email
+        then
+          let module DP = Data.Printer in
+          let* converted = acopy_email config (read ic) in
+          let print_both = begin
+              DP.print converted ;
+            end
+          in Ok print_both
+        else
+          acopy_mbox config ic
+    in
+      match processed with
+      | Error err -> write stderr (Error.message err) (* TODO: better error handling *)
+      | Ok _ -> ()
 
 let convert_wrapper config_files sem rpt rpt_p inp =
   let report_or_convert ic =

--- a/main.ml
+++ b/main.ml
@@ -87,7 +87,7 @@ let single_email_t = let doc = "Converts email attachments assuming the input is
 Arg.(value & flag & info ["single-email"] ~doc)
 
 let config_t =
-  let doc = "Sets $(docv) to be checked for a configuration file." in
+  let doc = "Sets the absolute path $(docv) to be checked for a configuration file." in
   Arg.(value & opt_all file [] & info ["config"] ~docv:"PATH" ~doc)
 
 let convert_t = Term.(const convert_wrapper $ config_t $ single_email_t $ report_t $ report_params_t $ input_t)


### PR DESCRIPTION
Fairly straightforward setup.

The default config assumes scripts are in `~/.config/attachment-converter/scripts`.

Did some mild testing and seems to be working fine. Don't have a great amount of time this week to work on this, so worth set up a pull and reviewing at this point.