### PR TITLE
72 progress bar should print to dev tty

### DIFF
--- a/lib/mbox.ml
+++ b/lib/mbox.ml
@@ -187,10 +187,10 @@ module ToOutput = struct
       let open Conversion (MBoxIterator (ChannelInput)) (ChannelOutput) in
         convert in_chan stdout converter
 
-    let acopy_mbox ?(idem=true) config in_chan =
+    let acopy_mbox ?(idem=true) config in_chan pbar =
       let module C = Convert.Conversion.Make (T) in
       let converter (fromline, em) =
-        match C.acopy_email ~idem:idem config em with
+        match C.acopy_email ~idem:idem config em pbar with
         | Ok converted -> fromline ^ "\n" ^ converted
         | Error _ ->
             let open ErrorHandling.Printer in

--- a/lib/progress_bar.ml
+++ b/lib/progress_bar.ml
@@ -1,8 +1,5 @@
-open Prelude
-
 module Printer = struct
-  let print msg =
-    if Unix.isatty (Unix.descr_of_out_channel stderr)
-    then prerr_endline msg
-    else ()
+  let print msg pbar =
+    output_string pbar (msg ^ "\n") ;
+    flush pbar
 end

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -20,7 +20,7 @@ let timestamp () =
     |> string_of_float
     |> fun x -> String.(sub x 0 (length x - 1))
 
-let rename_file id new_ext filename =
+let rename_file id new_ext filename pbar =
   let base = Filename.remove_extension filename in
   let new_filename =
     String.concat ""
@@ -48,7 +48,7 @@ let rename_file id new_ext filename =
           "..."
         ]
     in
-    Progress_bar.Printer.print msg
+    Progress_bar.Printer.print msg pbar
   in
   new_filename
 

--- a/main.ml
+++ b/main.ml
@@ -9,6 +9,8 @@
 open Prelude
 open Cmdliner
 
+let pbar_channel = open_out "/dev/tty"
+
 module Data = struct
   module Printer = struct
     let print msg = write stdout msg
@@ -41,7 +43,7 @@ let report ?(params=false) ic =
       (fun k v -> print ("  " ^ k ^ " : " ^ (Int.to_string v)))
       types
 
-let convert config_files ?(single_email=false) ic =
+let convert config_files ?(single_email=false) ic pbar =
   let open Lib.Convert.Converter in
   let open Lib.Configuration in
   let open Lib.ErrorHandling in
@@ -52,23 +54,24 @@ let convert config_files ?(single_email=false) ic =
         if single_email
         then
           let module DP = Data.Printer in
-          let* converted = acopy_email config (read ic) in
+          let* converted = acopy_email config (read ic) pbar in
           let print_both = begin
               DP.print converted ;
             end
           in Ok print_both
         else
-          acopy_mbox config ic
+          acopy_mbox config ic pbar
     in
       match processed with
       | Error err -> write stderr (Error.message err) (* TODO: better error handling *)
       | Ok _ -> ()
 
 let convert_wrapper config_files sem rpt rpt_p inp =
+  let pbar = open_out "/dev/tty" in 
   let report_or_convert ic =
     if rpt_p then report ~params:true ic
     else if rpt then report ic
-    else convert config_files ~single_email:sem ic in
+    else convert config_files ~single_email:sem ic pbar in
   match inp with
     | `File fn -> within (report_or_convert) fn
     | `Stdin -> report_or_convert stdin

--- a/main.ml
+++ b/main.ml
@@ -67,7 +67,11 @@ let convert config_files ?(single_email=false) ic pbar =
       | Ok _ -> ()
 
 let convert_wrapper config_files sem rpt rpt_p inp =
-  let pbar = open_out "/dev/tty" in 
+  let pbar = match open_out "/dev/tty" with
+    (* no controlling tty *)
+    | exception _ -> open_out "/dev/null"
+    | other -> other
+  in 
   let report_or_convert ic =
     if rpt_p then report ~params:true ic
     else if rpt then report ic


### PR DESCRIPTION
Fixes #72.

This involved adding a file handle parameter to `Progress_bar.Printer.print`, then propagating that file handle parameter up through all the functions that invoke it.