### PR TITLE
67 attachment converter should check that its dependencies are met

### DIFF
--- a/lib/dependency.ml
+++ b/lib/dependency.ml
@@ -36,10 +36,10 @@ module Error = struct
 
   let message err = match err with
   |`UnsupportedOS os -> 
-    os^" is not a supported operating system for Attachment Converter."
+    os^" is not a supported operating system for Attachment Converter.\n"
   |`NotInstalled lis -> 
     "The following applications still need to be installed:\n" ^ 
-    String.concat "\n" (List.map (let open Package in fun pckg -> pckg.packageName) lis)
+    String.concat "\n" (List.map (let open Package in fun pckg -> pckg.packageName) lis)^"\n"
 
 end
 
@@ -76,5 +76,5 @@ let checkDependencies () =
 let main () = 
   match checkDependencies () with
   |Ok _ -> ()
-  |Error e -> print_string (Error.message (e))
+  |Error e -> print_endline (Error.message (e))
 

--- a/lib/dependency.ml
+++ b/lib/dependency.ml
@@ -1,79 +1,97 @@
 open Prelude.Prereq
 
-type app = 
-  | LibreOffice
-  | Pandoc
-  | Vips
-  | GhostScript
-  | Verapdf
+module Application = struct
+  type t = 
+    | LibreOffice
+    | Pandoc
+    | Vips
+    | GhostScript
+    | Verapdf
+end
 
-type executable = validator
+module Package = struct 
+  type t = {app : Application.t; packageName: string; executable: validator}
 
-type packageName = PackageName of string
+  let linux : t list = [
+    {app = LibreOffice; packageName = "libreoffice"; executable = Exists "soffice"};
+    {app = Pandoc; packageName = "pandoc"; executable = Exists "pandoc"};
+    {app = Vips; packageName = "libvips"; executable = Exists "vips"};
+    {app = GhostScript; packageName = "ghostscript"; executable = Exists "gs"}
+  ]
 
-type package = (app * (packageName * executable)) list
+  let darwin : t list = [
+    {app = LibreOffice; packageName = "libreoffice"; executable = Exists "soffice"};
+    {app = Pandoc; packageName = "pandoc"; executable = Exists "pandoc"};
+    {app = Vips; packageName = "libvips"; executable = Exists "vips"};
+    {app = GhostScript; packageName = "ghostscript"; executable = Exists "gs"}
+  ]
 
-type platform = 
-  | Linux of package
-  | Darwin of package
+end
 
-let linux : package = [
-    (LibreOffice, (PackageName "libreoffice", Exists "soffice"))
-  ; (Pandoc, (PackageName "pandoc", Exists "pandoc"))
-  ; (Vips, (PackageName "libvips", Exists "vips"))
-  ; (GhostScript, (PackageName "ghostscript", Exists "gs"))
-]
+module Error = struct 
+  type t = [ 
+    |`NotInstalled of Package.t list (*keep track of the whole package*)
+    |`UnsupportedOS of string
+  ] 
 
-let darwin : package = [
-    (LibreOffice, (PackageName "libreoffice", Exists "soffice"))
-  ; (Pandoc, (PackageName "pandoc", Exists "pandoc"))
-  ; (Vips, (PackageName "libvips", Exists "vips"))
-  ; (GhostScript, (PackageName "ghostscript", Exists "gs"))
-]
+  let printError error = match error with
+    |`UnsupportedOS os -> print_endline (os^" is not a supported operating system for Attachment Converter.")
+    |`NotInstalled lis -> print_string "the following applications still need to be installed: "; List.iter (let open Package in fun pckg -> print_string (pckg.packageName^" ")) lis 
+end
 
-let getPackage pltfrm = match pltfrm with 
-  |Linux p -> p 
-  |Darwin p -> p 
+let getUserOS () = 
+  let open Prelude.Unix.Shell in
+  let userPltfrm = snd (input Prelude.readline @@ cmd ["uname";"-s"]) in
+    match userPltfrm with 
+      |"Linux" -> Ok (Package.linux)
+      |"Darwin" -> Ok (Package.darwin)
+      |_ -> Error (`UnsupportedOS userPltfrm)
 
-let getExecutables pltfrm = pltfrm |> getPackage |> List.map (fun pkg -> snd (snd pkg))
+let checkExecutables pkgs = 
+  let rec checkExecutables' (pkgs: Package.t list) acc = 
+    match pkgs with
+    |[] -> acc
+    |p::t -> 
+      match check [p.executable] with 
+      |(Ok _)::_ -> checkExecutables' t acc
+      |(Error _)::_ -> checkExecutables' t (acc @ [p]) 
+      |[] -> [] in 
+  let results = (checkExecutables' pkgs []) in 
+  match results with 
+    |[] -> Ok () 
+    |h::t -> Error (`NotInstalled (h::t))
 
-let fails res = 
+let checkDependencies () = 
+  let open Prelude.Result in   
+  let ( let* ) = (>>=) in 
+  let* userPckg = getUserOS () in 
+  match checkExecutables userPckg with 
+    |Ok _ -> Ok ()
+    |Error e -> Error.printError e; Error e
+
+
+
+
+
+ 
+(*make fails take the whole app and then ok if all results are or list is empty and error of list if something is missing*)
+(* let fails res = 
   let rec fails' res acc = match res with
     | [] -> acc
-    | h :: t -> begin
-      match h with
+    | (pn, exec) :: t -> begin
+      match exec with
       | Ok _ -> fails' t acc
-      | Error exec -> exec :: fails' t acc 
-      end
-  in fails' res []
+      | Error exec -> (pn, exec) :: fails' t acc 
+      end in 
+  match (fails' res [] ) with 
+  |[] -> Ok []
+  |lis -> Error (`NotInstalled lis) *)
 
+  
 
-let checkForExecutables pltfrm = pltfrm |> getExecutables |> check |> fails 
-
-
-let getPkgFromExec exec = 
-  let execNmToPkgNm = [
-    ("soffice", "libreoffice");
-    ("pandoc", "pandoc");
-    ("vips", "libvips");
-    ("gs", "ghostscript");
-    ("verapdf", "verapdf")
-  ] in 
-List.assoc exec execNmToPkgNm 
-
-let printMissingPkgs execs =
+(* let printMissingPkgs execs = (*this all gets handled by an error printer?*)
+  let open Error in 
   if execs = [] then () 
   else
     let execsString = String.concat ", " (List.map (fun x -> getPkgFromExec x) execs) in 
-    failwith (execsString ^ " still need(s) to be installed")
-
-let getPltfrm = 
-  let open Prelude.Unix.Shell in
-  let userPltfrm = snd (input Prelude.readline @@ cmd ["uname";"-s"]) in 
-    match userPltfrm with 
-      |"Linux" -> Linux linux
-      |"Darwin" -> Darwin darwin
-      |_ -> failwith (userPltfrm ^ " is not a supported platform")
-
-let checkDependencies = 
-  getPltfrm |> checkForExecutables |>  printMissingPkgs
+    failwith (execsString ^ " still need(s) to be installed") *)

--- a/lib/dependency.ml
+++ b/lib/dependency.ml
@@ -28,6 +28,11 @@ module Package = struct
     {app = GhostScript; packageName = "ghostscript"; executable = Exists "gs"}
   ]
 
+  let toString pckglist = 
+    if pckglist = linux then "linux: [" ^ String.concat ", " (List.map getName linux) ^ "]"
+    else if pckglist = darwin then "darwin: [" ^ String.concat ", " (List.map getName darwin) ^ "]"
+    else ""
+
 end
 
 module Error = struct 
@@ -37,12 +42,15 @@ module Error = struct
   ] 
 
   let message err = match err with
-  |`UnsupportedOS os -> 
-    os^" is not a supported operating system for Attachment Converter.\nHere is a list of supported Os-es:\n\n\tmacOS\n\tArch Linux\n\tWSL Debian\n\r"
-  |`NotInstalled lis -> 
-    "Attachment Converter will not run unless all of its OS-level dependencies are installed.\n\nIt looks like the following software packages still need to be installed:\n\t" ^ 
-    String.concat "\n\t" (List.map Package.getName lis)^"\n\r"
+    |`UnsupportedOS os -> 
+      os^" is not a supported operating system for Attachment Converter.\nHere is a list of supported Os-es:\n\n\tmacOS\n\tArch Linux\n\tWSL Debian\n\r"
+    |`NotInstalled lis -> 
+      "Attachment Converter will not run unless all of its OS-level dependencies are installed.\n\nIt looks like the following software packages still need to be installed:\n\t" ^ 
+      String.concat "\n\t" (List.map Package.getName lis)^"\n\r"
 
+  let toString err = match err with
+    |`UnsupportedOS os -> "`UnsupportedOS " ^ os 
+    |`NotInstalled lis -> "`NotInstalled [" ^ String.concat ", " (List.map Package.getName lis) ^ "]" 
 end
 
 let getUserOS () = 
@@ -64,7 +72,7 @@ let checkExecutables pkgs =
       |[] -> [] in 
   let results = (checkExecutables' pkgs []) in 
   match results with 
-    |[] -> Ok () 
+    |[] -> Ok ()
     |h::t -> Error (`NotInstalled (h::t))
 
 let checkDependencies () =

--- a/lib/dependency.ml
+++ b/lib/dependency.ml
@@ -1,103 +1,79 @@
 open Prelude.Prereq
 
-type platform = 
-        | Linux
-        | Darwin
-        | WSL
-        | MacOS
-
 type app = 
-        | LibreOffice
-        | Pandoc
-        | Vips
-        | GhostScript
-        | Verapdf
+  | LibreOffice
+  | Pandoc
+  | Vips
+  | GhostScript
+  | Verapdf
 
-type packageName = PackageName of string
 type executable = validator
 
+type packageName = PackageName of string
+
 type package = (app * (packageName * executable)) list
-type lookup = (platform * package) list
+
+type platform = 
+  | Linux of package
+  | Darwin of package
 
 let linux : package = [
-          (LibreOffice, (PackageName "libreoffice", Exists "soffice"))
-        ; (Pandoc, (PackageName "pandoc", Exists "pandoc"))
-        ; (Vips, (PackageName "libvips", Exists "vips"))
-        ; (GhostScript, (PackageName "ghostscript", Exists "gs"))
+    (LibreOffice, (PackageName "libreoffice", Exists "soffice"))
+  ; (Pandoc, (PackageName "pandoc", Exists "pandoc"))
+  ; (Vips, (PackageName "libvips", Exists "vips"))
+  ; (GhostScript, (PackageName "ghostscript", Exists "gs"))
 ]
 
 let darwin : package = [
-          (LibreOffice, (PackageName "libreoffice", Exists "soffice"))
-        ; (Pandoc, (PackageName "pandoc", Exists "pandoc"))
-        ; (Vips, (PackageName "libvips", Exists "vips"))
-        ; (GhostScript, (PackageName "ghostscript", Exists "gs"))
+    (LibreOffice, (PackageName "libreoffice", Exists "soffice"))
+  ; (Pandoc, (PackageName "pandoc", Exists "pandoc"))
+  ; (Vips, (PackageName "libvips", Exists "vips"))
+  ; (GhostScript, (PackageName "ghostscript", Exists "gs"))
 ]
 
-let wsl : package = [
-          (LibreOffice, (PackageName "libreoffice", Exists "soffice"))
-        ; (Pandoc, (PackageName "pandoc", Exists "pandoc"))
-        ; (Vips, (PackageName "libvips", Exists "vips"))
-        ; (GhostScript, (PackageName "ghostscript", Exists "gs"))
-        ; (Verapdf, (PackageName "verapdf", Exists "verapdf"))
-]
+let getPackage pltfrm = match pltfrm with 
+  |Linux p -> p 
+  |Darwin p -> p 
 
-let macos : package = [
-          (LibreOffice, (PackageName "libreoffice", Exists "soffice"))
-        ; (Pandoc, (PackageName "pandoc", Exists "pandoc"))
-        ; (Vips, (PackageName "libvips", Exists "vips"))
-        ; (GhostScript, (PackageName "ghostscript", Exists "gs"))
-        ; (Verapdf, (PackageName "verapdf", Exists "verapdf"))
-]
-
-
-(*
-        TODO: Delete this and use previous macos value on line 44. 
-        This is for testing.
-*)
-let macos : package = [
-          (LibreOffice, (PackageName "libreoffice", Exists "soffice1"))
-        ; (Pandoc, (PackageName "pandoc", Exists "pandoc"))
-        ; (Vips, (PackageName "libvips", Exists "vips1"))
-        ; (GhostScript, (PackageName "ghostscript", Exists "gs"))
-        ; (Verapdf, (PackageName "verapdf", Exists "verapdf1"))
-]
-
-let pltfrmToPkgs : lookup = [
-          (Linux, linux)
-        ; (Darwin, darwin)
-        ; (WSL, wsl)
-        ; (MacOS, macos)
-]
-
-let listPackages pltfrm = List.assoc pltfrm pltfrmToPkgs
-
-let getExecutables pltfrm = pltfrm |> listPackages |> List.map (fun pkg -> snd (snd pkg))
-
+let getExecutables pltfrm = pltfrm |> getPackage |> List.map (fun pkg -> snd (snd pkg))
 
 let fails res = 
-        let rec fails' res acc = match res with
-                | [] -> acc
-                | h :: t -> begin
-                        match h with
-                        | Ok _ -> fails' t acc
-                        | Error exec -> exec :: fails' t acc 
-                end
-        in fails' res []
-
-(*
-TODO: make platform - package into a sum type
-*)
-let checkDependencies pltfrm = pltfrm |> getExecutables |> check |> fails 
+  let rec fails' res acc = match res with
+    | [] -> acc
+    | h :: t -> begin
+      match h with
+      | Ok _ -> fails' t acc
+      | Error exec -> exec :: fails' t acc 
+      end
+  in fails' res []
 
 
-(*
-let getExecutables pltfrm =
-        let pkgs = listPackages pltfrm in 
-                List.map (fun pkg -> snd (snd pkg)) pkgs
-*)
+let checkForExecutables pltfrm = pltfrm |> getExecutables |> check |> fails 
 
-(*
-        This is a lookup table from Executale names to package names. 
-        soffice -> libreoffice
-*)
-let getPkgFromExec pkg = ()
+
+let getPkgFromExec exec = 
+  let execNmToPkgNm = [
+    ("soffice", "libreoffice");
+    ("pandoc", "pandoc");
+    ("vips", "libvips");
+    ("gs", "ghostscript");
+    ("verapdf", "verapdf")
+  ] in 
+List.assoc exec execNmToPkgNm 
+
+let printMissingPkgs execs =
+  if execs = [] then () 
+  else
+    let execsString = String.concat ", " (List.map (fun x -> getPkgFromExec x) execs) in 
+    failwith (execsString ^ " still need(s) to be installed")
+
+let getPltfrm = 
+  let open Prelude.Unix.Shell in
+  let userPltfrm = snd (input Prelude.readline @@ cmd ["uname";"-s"]) in 
+    match userPltfrm with 
+      |"Linux" -> Linux linux
+      |"Darwin" -> Darwin darwin
+      |_ -> failwith (userPltfrm ^ " is not a supported platform")
+
+let checkDependencies = 
+  getPltfrm |> checkForExecutables |>  printMissingPkgs

--- a/lib/dependency.ml
+++ b/lib/dependency.ml
@@ -1,0 +1,103 @@
+open Prelude.Prereq
+
+type platform = 
+        | Linux
+        | Darwin
+        | WSL
+        | MacOS
+
+type app = 
+        | LibreOffice
+        | Pandoc
+        | Vips
+        | GhostScript
+        | Verapdf
+
+type packageName = PackageName of string
+type executable = validator
+
+type package = (app * (packageName * executable)) list
+type lookup = (platform * package) list
+
+let linux : package = [
+          (LibreOffice, (PackageName "libreoffice", Exists "soffice"))
+        ; (Pandoc, (PackageName "pandoc", Exists "pandoc"))
+        ; (Vips, (PackageName "libvips", Exists "vips"))
+        ; (GhostScript, (PackageName "ghostscript", Exists "gs"))
+]
+
+let darwin : package = [
+          (LibreOffice, (PackageName "libreoffice", Exists "soffice"))
+        ; (Pandoc, (PackageName "pandoc", Exists "pandoc"))
+        ; (Vips, (PackageName "libvips", Exists "vips"))
+        ; (GhostScript, (PackageName "ghostscript", Exists "gs"))
+]
+
+let wsl : package = [
+          (LibreOffice, (PackageName "libreoffice", Exists "soffice"))
+        ; (Pandoc, (PackageName "pandoc", Exists "pandoc"))
+        ; (Vips, (PackageName "libvips", Exists "vips"))
+        ; (GhostScript, (PackageName "ghostscript", Exists "gs"))
+        ; (Verapdf, (PackageName "verapdf", Exists "verapdf"))
+]
+
+let macos : package = [
+          (LibreOffice, (PackageName "libreoffice", Exists "soffice"))
+        ; (Pandoc, (PackageName "pandoc", Exists "pandoc"))
+        ; (Vips, (PackageName "libvips", Exists "vips"))
+        ; (GhostScript, (PackageName "ghostscript", Exists "gs"))
+        ; (Verapdf, (PackageName "verapdf", Exists "verapdf"))
+]
+
+
+(*
+        TODO: Delete this and use previous macos value on line 44. 
+        This is for testing.
+*)
+let macos : package = [
+          (LibreOffice, (PackageName "libreoffice", Exists "soffice1"))
+        ; (Pandoc, (PackageName "pandoc", Exists "pandoc"))
+        ; (Vips, (PackageName "libvips", Exists "vips1"))
+        ; (GhostScript, (PackageName "ghostscript", Exists "gs"))
+        ; (Verapdf, (PackageName "verapdf", Exists "verapdf1"))
+]
+
+let pltfrmToPkgs : lookup = [
+          (Linux, linux)
+        ; (Darwin, darwin)
+        ; (WSL, wsl)
+        ; (MacOS, macos)
+]
+
+let listPackages pltfrm = List.assoc pltfrm pltfrmToPkgs
+
+let getExecutables pltfrm = pltfrm |> listPackages |> List.map (fun pkg -> snd (snd pkg))
+
+
+let fails res = 
+        let rec fails' res acc = match res with
+                | [] -> acc
+                | h :: t -> begin
+                        match h with
+                        | Ok _ -> fails' t acc
+                        | Error exec -> exec :: fails' t acc 
+                end
+        in fails' res []
+
+(*
+TODO: make platform - package into a sum type
+*)
+let checkDependencies pltfrm = pltfrm |> getExecutables |> check |> fails 
+
+
+(*
+let getExecutables pltfrm =
+        let pkgs = listPackages pltfrm in 
+                List.map (fun pkg -> snd (snd pkg)) pkgs
+*)
+
+(*
+        This is a lookup table from Executale names to package names. 
+        soffice -> libreoffice
+*)
+let getPkgFromExec pkg = ()

--- a/lib/dependency.ml
+++ b/lib/dependency.ml
@@ -11,6 +11,8 @@ end
 
 module Package = struct 
   type t = {app : Application.t; packageName: string; executable: validator}
+  
+  let getName pckg = pckg.packageName
 
   let linux : t list = [
     {app = LibreOffice; packageName = "libreoffice"; executable = Exists "soffice"};
@@ -36,10 +38,10 @@ module Error = struct
 
   let message err = match err with
   |`UnsupportedOS os -> 
-    os^" is not a supported operating system for Attachment Converter.\n"
+    os^" is not a supported operating system for Attachment Converter.\nHere is a list of supported Os-es:\n\n\tmacOS\n\tArch Linux\n\tWSL Debian\n\r"
   |`NotInstalled lis -> 
-    "The following applications still need to be installed:\n" ^ 
-    String.concat "\n" (List.map (let open Package in fun pckg -> pckg.packageName) lis)^"\n"
+    "Attachment Converter will not run unless all of its OS-level dependencies are installed.\n\nIt looks like the following software packages still need to be installed:\n\t" ^ 
+    String.concat "\n\t" (List.map Package.getName lis)^"\n\r"
 
 end
 

--- a/lib/dune
+++ b/lib/dune
@@ -5,8 +5,21 @@
 (library
  (name lib)
  (libraries prelude mrmime threads netstring unix re)
- (modules lib configuration errorHandling report convert mbox header utils serialize skeleton progress_bar))
+ (modules
+  lib
+  configuration
+  errorHandling
+  report
+  convert
+  mbox
+  header
+  utils
+  serialize
+  skeleton
+  progress_bar
+  dependency))
 
 (env
-  (dev                                  ; make warnings non-fatal
-    (flags (:standard -warn-error -A))))
+ (dev ; make warnings non-fatal
+  (flags
+   (:standard -warn-error -A))))

--- a/lib/errorHandling.ml
+++ b/lib/errorHandling.ml
@@ -3,15 +3,18 @@ open Utils
 module _ : ERROR = Configuration.ParseConfig.Error
 module _ : ERROR = Header.Field.Value.Error
 module _ : ERROR = Convert.Converter.Error
+module _ : ERROR = Dependency.Error
 
 module Error : ERROR with
   type t = [
     | Convert.Converter.Error.t
     | Configuration.ParseConfig.Error.t
+    | Dependency.Error.t
   ] = struct
   type t = [
     | Convert.Converter.Error.t
     | Configuration.ParseConfig.Error.t
+    | Dependency.Error.t
   ]
 
   let message err =
@@ -20,6 +23,8 @@ module Error : ERROR with
         Convert.Converter.Error.message e
     | #Configuration.ParseConfig.Error.t as e ->
         Configuration.ParseConfig.Error.message e
+    | #Dependency.Error.t as e ->
+        Dependency.Error.message e
 end
 
 module Printer = struct

--- a/lib/lib.ml
+++ b/lib/lib.ml
@@ -13,6 +13,7 @@ module Progress_bar  = Progress_bar
 module Header        = Header
 module Serialize     = Serialize
 module Skeleton      = Skeleton
+module Dependency    = Dependency
 
 (*
  * Copyright (c) 2021 Matt Teichman

--- a/main.ml
+++ b/main.ml
@@ -50,6 +50,7 @@ let convert config_files ?(single_email=false) ic pbar =
   let open Lib.Mbox.Copier in
   let ( let* ) = Result.(>>=) in
     let processed =
+      let open Lib.Dependency in let* _ = checkDependencies () in
       let* config = get_config config_files in
         if single_email
         then

--- a/tests/dependency_tests.ml
+++ b/tests/dependency_tests.ml
@@ -4,21 +4,15 @@ open Prelude.Prereq
 open Prelude.Unix.Shell
 open Lib.Dependency
 
-let getUserOS_test1_Linux = 
+let getUserOS_test_Linux = 
   let test _ = (skip_if (snd (input Prelude.readline @@ cmd ["uname";"-s"]) = "Darwin") "this test won't run work with MaCOS"); 
   assert_equal (Ok Package.linux) (getUserOS ()) in 
   "check that correct package is assigned for Linux machine" >:: test 
 
-let getUserOS_test1_Darwin = 
+let getUserOS_test_Darwin = 
   let test _ = (skip_if (snd (input Prelude.readline @@ cmd ["uname";"-s"]) = "Linux") "this test won't run work with Linux"); 
   assert_equal (Ok Package.darwin) (getUserOS ()) in 
   "check that correct package is assigned for Darwin machine" >:: test
-
-(* let getUserOS_test2 = 
-  check_eq_basic 
-  "check that error is triggered if user is using an unsupported os"
-  (Error (`UnsupportedOS "put example text in here"))
-  (getUserOS ()) *)
 
 let checkExecutables_test1_Linux =
   let test _ =  (skip_if (snd (input Prelude.readline @@ cmd ["uname";"-s"]) = "Darwin") "this test won't run work with MaCOS");
@@ -57,10 +51,9 @@ let printError_testNotInstalled =
 
 let tests = 
    "test suite for dependency" >:::
-   [
-    getUserOS_test1_Linux;
-    getUserOS_test1_Darwin;
-    (* getUserOS_test2; *)
+   [ 
+    getUserOS_test_Linux;
+    getUserOS_test_Darwin;
     checkExecutables_test1_Linux;
     checkExecutables_test1_Darwin;
     checkExecutables_test2;

--- a/tests/dependency_tests.ml
+++ b/tests/dependency_tests.ml
@@ -1,0 +1,56 @@
+open OUnit2
+open Lib.Dependency
+open Utils 
+open Prelude.Prereq
+
+let getPackage_test = 
+   check_eq_basic 
+   "check for return of correct package" 
+   (linux) 
+   (getPackage (Linux linux))
+
+let getPkgFromExec_test = 
+   check_eq_basic
+   "check for return of corresponding package name" 
+   ("libreoffice") 
+   (getPkgFromExec "soffice")
+
+let printMissingPkgs_test1 = 
+   check_eq_basic
+   "check does nothing when all dependencies met" 
+   ()
+   (printMissingPkgs [])
+
+let checkForExecutables_test1 = 
+   check_eq_basic 
+   "check that an empty list is returned when no executables / packages are missing"
+   ([])
+   (checkForExecutables (Linux linux))
+
+let getPltfrm_test1 = 
+   check_eq_basic
+   "check that correct platform and package is assigned if a supported platform" (*assuming a linux machine*)
+   (Linux linux)
+   (getPltfrm) (*need to find a way to check output of command on all four platforms*)
+
+let checkDependencies_test = (*if getPltfrm, checkforexec, and printmissing all work then this should as well*)
+   check_eq_basic
+   "check that nothing happens when run on a machine where all dependencies are met"
+   ()
+   (checkDependencies)
+
+let tests = 
+   "test suite for dependency" >:::
+   [
+      getPackage_test;
+      getPkgFromExec_test;
+      printMissingPkgs_test1;
+      "check that exception is raised when packages are missing" >:: (fun _ -> assert_raises (Failure "libvips, ghostscript still need to be installed") (fun () -> printMissingPkgs ["vips"; "gs"])); (*OK on my machine*)
+      "check for return of correct executables" >:: (fun _ -> assert_equal [Exists "soffice"; Exists "pandoc"; Exists "vips"; Exists "gs"] (getExecutables (Linux linux)));
+      checkForExecutables_test1;
+      getPltfrm_test1;
+      checkDependencies_test;
+      (* "check that unsupported os triggers exception" >:: (fun _ -> assert_raises (Failure " is not a supported platform") (fun () -> getPltfrm)); *) (*only works if hardcode bad input into getPltfrm*)
+   ]
+   
+let _ = run_test_tt_main tests

--- a/tests/dependency_tests.ml
+++ b/tests/dependency_tests.ml
@@ -5,22 +5,23 @@ open Prelude.Unix.Shell
 open Lib.Dependency
 
 let getUserOS_test_Linux = 
-  let test _ = (skip_if (snd (input Prelude.readline @@ cmd ["uname";"-s"]) = "Darwin") "this test won't run work with MaCOS"); 
+  let test _ = (skip_if (snd (input Prelude.readline @@ cmd ["uname";"-s"]) = "Darwin") "this test won't run with MaCOS"); 
   assert_equal (Ok Package.linux) (getUserOS ()) in 
   "check that correct package is assigned for Linux machine" >:: test 
 
+
 let getUserOS_test_Darwin = 
-  let test _ = (skip_if (snd (input Prelude.readline @@ cmd ["uname";"-s"]) = "Linux") "this test won't run work with Linux"); 
+  let test _ = (skip_if (snd (input Prelude.readline @@ cmd ["uname";"-s"]) = "Linux") "this test won't run with Linux"); 
   assert_equal (Ok Package.darwin) (getUserOS ()) in 
   "check that correct package is assigned for Darwin machine" >:: test
 
 let checkExecutables_test1_Linux =
-  let test _ =  (skip_if (snd (input Prelude.readline @@ cmd ["uname";"-s"]) = "Darwin") "this test won't run work with MaCOS");
+  let test _ =  (skip_if (snd (input Prelude.readline @@ cmd ["uname";"-s"]) = "Darwin") "this test won't run with MaCOS");
   assert_equal (Ok ()) (checkExecutables Package.linux) in 
   "check that checkExecutables returns an empty result is returned when all dependencies are met" >:: test
   
 let checkExecutables_test1_Darwin =
-  let test _ =  (skip_if (snd (input Prelude.readline @@ cmd ["uname";"-s"]) = "Linux") "this test won't run work with Linux");
+  let test _ =  (skip_if (snd (input Prelude.readline @@ cmd ["uname";"-s"]) = "Linux") "this test won't run with Linux");
   assert_equal (Ok ()) (checkExecutables Package.darwin) in 
   "check that checkExecutables returns an empty result is returned when all dependencies are met" >:: test
 
@@ -37,16 +38,16 @@ let checkDependencies_test =
   (checkDependencies ())
 
 let printError_testUnsupported =  
-  check_eq_basic
+  check_eq_string
   "test that error message for unsupported operating system displays correctly"
-  ("MacOS is not a supported operating system for Attachment Converter.")
-  (Error.message (`UnsupportedOS "MacOS"))
+  ("BadOS is not a supported operating system for Attachment Converter.\nHere is a list of supported Os-es:\n\n\tmacOS\n\tArch Linux\n\tWSL Debian\n\r")
+  (Error.message (`UnsupportedOS "BadOS"))
 
 let printError_testNotInstalled = 
   let open Package in
-  check_eq_basic
+  check_eq_string
   "check that the error message for uninstalled dependencies displays correctly"
-  ("The following applications still need to be installed:\npandoc\nlibvips")
+  ("Attachment Converter will not run unless all of its OS-level dependencies are installed.\n\nIt looks like the following software packages still need to be installed:\n\tpandoc\n\tlibvips\n\r")
   (Error.message (`NotInstalled [{app = Pandoc; packageName = "pandoc"; executable = Exists "pandoc"}; {app = Vips; packageName = "libvips"; executable = Exists "vips"}]))
 
 let tests = 

--- a/tests/dependency_tests.ml
+++ b/tests/dependency_tests.ml
@@ -39,20 +39,21 @@ let checkExecutables_test2 =
 let checkDependencies_test = 
   check_eq_basic
   "check that nothing happens when the OS and Dependencies are all good to go"
-  (Ok ())
+  (Ok "")
   (checkDependencies ())
 
-(* let printError_testUnsupported = 
+let printError_testUnsupported =  
   check_eq_basic
+  "test that error message for unsupported operating system displays correctly"
   ("MacOS is not a supported operating system for Attachment Converter.")
-  (Error.printError (`UnsupportedOS "MacOS"))
+  (Error.message (`UnsupportedOS "MacOS"))
 
 let printError_testNotInstalled = 
-  let open Error in
   let open Package in
   check_eq_basic
-  ("the following applications still need to be installed: pandoc libvips")
-  (printError (`NotInstalled [{app = Pandoc; packageName = "pandoc"; executable = Exists "pandoc"}; {app = Vips; packageName = "libvips"; executable = Exists "vips"}])) *)
+  "check that the error message for uninstalled dependencies displays correctly"
+  ("The following applications still need to be installed:\npandoc\nlibvips")
+  (Error.message (`NotInstalled [{app = Pandoc; packageName = "pandoc"; executable = Exists "pandoc"}; {app = Vips; packageName = "libvips"; executable = Exists "vips"}]))
 
 let tests = 
    "test suite for dependency" >:::
@@ -64,9 +65,8 @@ let tests =
     checkExecutables_test1_Darwin;
     checkExecutables_test2;
     checkDependencies_test;
-    (* printError_testUnsupported;
+    printError_testUnsupported;
     printError_testNotInstalled;
- *)
    ]
    
 let _ = run_test_tt_main tests

--- a/tests/dependency_tests.ml
+++ b/tests/dependency_tests.ml
@@ -31,9 +31,9 @@ let getPltfrm_test1 =
    check_eq_basic
    "check that correct platform and package is assigned if a supported platform" (*assuming a linux machine*)
    (Linux linux)
-   (getPltfrm) (*need to find a way to check output of command on all four platforms*)
+   (getPltfrm)
 
-let checkDependencies_test = (*if getPltfrm, checkforexec, and printmissing all work then this should as well*)
+let checkDependencies_test =
    check_eq_basic
    "check that nothing happens when run on a machine where all dependencies are met"
    ()
@@ -45,10 +45,10 @@ let tests =
       getPackage_test;
       getPkgFromExec_test;
       printMissingPkgs_test1;
-      "check that exception is raised when packages are missing" >:: (fun _ -> assert_raises (Failure "libvips, ghostscript still need to be installed") (fun () -> printMissingPkgs ["vips"; "gs"])); (*OK on my machine*)
+      "check that exception is raised when packages are missing" >:: (fun _ -> assert_raises (Failure "libvips, ghostscript still need to be installed") (fun () -> printMissingPkgs ["vips"; "gs"]));
       "check for return of correct executables" >:: (fun _ -> assert_equal [Exists "soffice"; Exists "pandoc"; Exists "vips"; Exists "gs"] (getExecutables (Linux linux)));
       checkForExecutables_test1;
-      getPltfrm_test1;
+      getPltfrm_test1; (*this assumes you're using a linux / windows machine*)
       checkDependencies_test;
       (* "check that unsupported os triggers exception" >:: (fun _ -> assert_raises (Failure " is not a supported platform") (fun () -> getPltfrm)); *) (*only works if hardcode bad input into getPltfrm*)
    ]

--- a/tests/dune
+++ b/tests/dune
@@ -1,10 +1,11 @@
 (tests
-  (names
-    config_tests
-    mbox_tests
-    param_tests
-    field_value_tests
-    field_tests
-    header_tests
-    serialize_tests)
-  (libraries lib ounit2))
+ (names
+  config_tests
+  mbox_tests
+  param_tests
+  field_value_tests
+  field_tests
+  header_tests
+  serialize_tests
+  dependency_tests)
+ (libraries lib ounit2))


### PR DESCRIPTION
Addresses #67, attachment converter should now check that user is running either MacOS or Windows and that LibreOffice, Pandoc, Vips, and GhostScript are installed. If an unsupported operating system is being used a message will print informing the user their OS is unsupported. If packages are missing, a message will print listing what still needs to be installed. Verapdf is still listed as an application in case we want to check for it later, but the current dependency file does not check for it. 
This can be tested on a machine that does not have one of the dependencies installed, or there are some unit tests in dependency_tests, though some of these assume you are using a linux / windows machine.