### PR TITLE
Only print Skeleton if there are attachments to convert

### DIFF
--- a/lib/convert.ml
+++ b/lib/convert.ml
@@ -115,7 +115,7 @@ module Mrmime_parsetree = struct
     let mime_ty = ty ^ "/" ^ subty in
     let params =
       let form (name, value) =
-        Header.Field.Value.Parameter.make_
+        Header.Field.Value.Parameter.make
           name
           (match value with `String s -> s | `Token s -> s) (* TODO: Is this really necessary? *)
         in
@@ -365,7 +365,7 @@ module Conversion = struct
       let cd_header_val =
         let value = "attachment" in
         let params =
-          [ "filename", md.filename;
+          [ "filename", quoted md.filename;
           ]
         in
           Header.Field.Value.make

--- a/lib/convert.ml
+++ b/lib/convert.ml
@@ -482,7 +482,7 @@ module Conversion = struct
     let attachments_to_convert ?(idem=true) config tree =
       let open Parsetree_utils(T) in
       let match_convs att =
-        let dname = "UNNAMED ATTACHMENT" in
+        let dname = "UNNAMED_ATTACHMENT" in
         let add_name c = (Option.default dname (attachment_name att), c) in
         map add_name (to_convert ~idem config tree att)
       in concat_map match_convs (attachments tree)

--- a/lib/convert.ml
+++ b/lib/convert.ml
@@ -491,7 +491,7 @@ module Conversion = struct
       let open Configuration.TransformData in
       String.concat ""
         [ name
-        ;  " --> "
+        ;  " to "
         ;  Mime_type.to_string (target_type conv)
         ;  " ("
         ;  convert_id conv
@@ -504,6 +504,7 @@ module Conversion = struct
       let* tree = Result.witherr (k `EmailParse) (T.of_string email) in
       let convs = attachments_to_convert ~idem config tree in
       if List.empty convs then
+        let () = Progress_bar.Printer.print "Nothing to convert...\nProcessing complete." pbar in
         Ok (T.to_string tree)
       else
         let () =
@@ -522,10 +523,9 @@ module Conversion = struct
           let lines =
             [ "Conversions to perform...\n"
             ; "=================================\n"
-            ] @
-            map (fun c -> display_conv c ^ "\n") convs @
-            [ "\n"
-            ; "=================================\n"
+            ; String.join ~sep:"\n" (map display_conv convs)
+            ; "\n"
+            ; "================================="
             ]
           in
           let msg = String.concat "" lines in

--- a/tests/field_value_tests.ml
+++ b/tests/field_value_tests.ml
@@ -45,7 +45,7 @@ let to_string_test2 =
 let lookup_param_test1 =
   check_eq_basic
     "basic lookup_param test"
-    (Some "\"test.gif\"")
+    (Some "test.gif")
     (lookup_param "filename" cd)
 
 let update_tests =


### PR DESCRIPTION
The progress bar should now only print the skeleton of an email if there are attachments to convert. It will also list the conversions it is going to do.

On an email with conversions:
```
$ dune exec -- ./main.exe < test2.eml > out.eml 
Parsing email...                    
Processing email with structure...
=================================
Multipart
|-- Multipart
|   |-- Body
|   |-- Body
|-- Attachment: online_cap_tapev2.pdf
=================================
Conversions to perform...
=================================
online_cap_tapev2.pdf to application/pdf (soffice-pdf-to-pdf)
online_cap_tapev2.pdf to text/plain (pdftotext-pdf-to-txt)
=================================
Converting online_cap_tapev2.pdf to online_cap_tapev2_CONVERTED1709333305.pdf (PDF-A)...
Converting online_cap_tapev2.pdf to online_cap_tapev2_CONVERTED1709333315.txt...
Email now has structure...
=================================
Multipart
|-- Multipart
|   |-- Body
|   |-- Body
|-- Attachment: online_cap_tapev2.pdf
|-- CONVERTED Attachment: online_cap_tapev2_CONVERTED1709333305.pdf
|-- CONVERTED Attachment: online_cap_tapev2_CONVERTED1709333315.txt
=================================
Processing complete.
```
And then running again on the output (with idempotence)
```
$ dune exec -- ./main.exe < out.eml > out2.eml
Parsing email...                   
Nothing to convert...
Processing complete.
```
I also fixed a bug in which quotes around filenames were being dropped. We will have to make clear in the documentation that `Parameter.value` returns an unquoted value by default.