### PR TITLE
94 scrub bad result handling

### DIFF
--- a/lib/convert.ml
+++ b/lib/convert.ml
@@ -10,13 +10,21 @@ module Attachment = struct
 end
 
 let gen_multi_header =
-  Result.get_ok
-    (Header.of_assoc_list
-       [ ( "Content-Type",
-           "multipart/mixed; boundary=attachment converter \
-            generated boundary" );
-         (Constants.meta_header_name, "generated multipart")
-       ] )
+  let open Header in
+  of_list
+    [ Field.make
+        "Content-Type"
+        (Field.Value.make
+           "multipart/mixed"
+           ~params:
+             [ Field.Value.Parameter.make
+                 "boundary"
+                 "attachment converter generated boundary"
+             ])
+    ; Field.make
+        Constants.meta_header_name
+        (Field.Value.make "generated multipart")
+    ]
 
 module type PARSETREE = sig
   module Error : ERROR

--- a/lib/convert.ml
+++ b/lib/convert.ml
@@ -79,6 +79,7 @@ end
 
 module Mrmime_parsetree = struct
   exception HeaderRepresentationError
+
   module Error = struct
     type t = [`EmailParse]
 

--- a/lib/convert.ml
+++ b/lib/convert.ml
@@ -78,6 +78,7 @@ module Parsetree_utils (T : PARSETREE) = struct
 end
 
 module Mrmime_parsetree = struct
+  exception HeaderRepresentationError
   module Error = struct
     type t = [`EmailParse]
 
@@ -97,11 +98,12 @@ module Mrmime_parsetree = struct
   let to_string = Serialize.(make >> to_string)
   let header = fst
 
-  let make_header =
-    Header.to_string
-    >> Angstrom.parse_string ~consume:All
-         (Mrmime.Header.Decoder.header None)
-    >> Result.get_ok (* TODO *)
+  let make_header h =
+    let decoder = Mrmime.Header.Decoder.header None in
+    let of_string = Angstrom.parse_string ~consume:All decoder in
+    match of_string (Header.to_string h) with
+    | Ok h -> h
+    | Error _ -> raise HeaderRepresentationError
 
   let of_list (l : t list) =
     match len l with

--- a/lib/convert.ml
+++ b/lib/convert.ml
@@ -12,17 +12,13 @@ end
 let gen_multi_header =
   let open Header in
   of_list
-    [ Field.make
-        "Content-Type"
-        (Field.Value.make
-           "multipart/mixed"
+    [ Field.make "Content-Type"
+        (Field.Value.make "multipart/mixed"
            ~params:
-             [ Field.Value.Parameter.make
-                 "boundary"
+             [ Field.Value.Parameter.make "boundary"
                  "attachment converter generated boundary"
-             ])
-    ; Field.make
-        Constants.meta_header_name
+             ] );
+      Field.make Constants.meta_header_name
         (Field.Value.make "generated multipart")
     ]
 
@@ -101,7 +97,9 @@ module Mrmime_parsetree = struct
 
   let make_header h =
     let decoder = Mrmime.Header.Decoder.header None in
-    let of_string = Angstrom.parse_string ~consume:All decoder in
+    let of_string =
+      Angstrom.parse_string ~consume:All decoder
+    in
     match of_string (Header.to_string h) with
     | Ok h -> h
     | Error _ -> raise HeaderRepresentationError
@@ -119,8 +117,7 @@ module Mrmime_parsetree = struct
     let* field = List.head (Mrmime.Header.assoc fname hd) in
     match field with
     | Field (_, Unstructured, data) ->
-      ( Prettym.to_string
-          ~margin:Constants.max_line_length
+      ( Prettym.to_string ~margin:Constants.max_line_length
           Mrmime.Unstructured.Encoder.unstructured
       >> Header.Field.Value.of_string
       >> Result.to_option )
@@ -423,17 +420,12 @@ module Conversion = struct
           value
       in
       of_list
-        [ Field.make
-            "Content-Transfer-Encoding"
-            (Field.Value.make "base64")
-        ; Field.make
-            "Content-Type"
-            (Field.Value.make md.target_type)
-        ; Field.make
-            "Content-Disposition"
-            cd_header_val
-        ; Field.make
-            "X-Attachment-Converter"
+        [ Field.make "Content-Transfer-Encoding"
+            (Field.Value.make "base64");
+          Field.make "Content-Type"
+            (Field.Value.make md.target_type);
+          Field.make "Content-Disposition" cd_header_val;
+          Field.make "X-Attachment-Converter"
             meta_header_val
         ]
 

--- a/lib/convert.ml
+++ b/lib/convert.ml
@@ -391,6 +391,7 @@ module Conversion = struct
       }
 
     let create_new_header md =
+      let open Header in
       let meta_header_val =
         let value = "converted" in
         let params =
@@ -401,33 +402,37 @@ module Conversion = struct
             ("original-file-hash", md.hashed)
           ]
         in
-        Header.Field.Value.make
+        Field.Value.make
           ~params:
             (map
-               (uncurry Header.Field.Value.Parameter.make)
+               (uncurry Field.Value.Parameter.make)
                params )
           value
       in
       let cd_header_val =
         let value = "attachment" in
         let params = [ ("filename", quoted md.filename) ] in
-        Header.Field.Value.make
+        Field.Value.make
           ~params:
             (map
-               (uncurry Header.Field.Value.Parameter.make)
+               (uncurry Field.Value.Parameter.make)
                params )
           value
       in
-      Result.get_ok
-        (Header.of_assoc_list
-           [ ("Content-Transfer-Encoding", "base64");
-             ("Content-Type", md.target_type);
-             ( "Content-Disposition",
-               Header.Field.Value.to_string cd_header_val );
-             ( "X-Attachment-Converter",
-               Header.Field.Value.to_string meta_header_val
-             )
-           ] )
+      of_list
+        [ Field.make
+            "Content-Transfer-Encoding"
+            (Field.Value.make "base64")
+        ; Field.make
+            "Content-Type"
+            (Field.Value.make md.target_type)
+        ; Field.make
+            "Content-Disposition"
+            cd_header_val
+        ; Field.make
+            "X-Attachment-Converter"
+            meta_header_val
+        ]
 
     let convert_attachment att pbar md =
       let convert_data str =

--- a/lib/convert.ml
+++ b/lib/convert.ml
@@ -116,7 +116,9 @@ module Mrmime_parsetree = struct
     let* field = List.head (Mrmime.Header.assoc fname hd) in
     match field with
     | Field (_, Unstructured, data) ->
-      ( Mrmime.Unstructured.to_string
+      ( Prettym.to_string
+          ~margin:Constants.max_line_length
+          Mrmime.Unstructured.Encoder.unstructured
       >> Header.Field.Value.of_string
       >> Result.to_option )
         data

--- a/lib/serialize.ml
+++ b/lib/serialize.ml
@@ -177,7 +177,9 @@ let map f stream =
 let stream_of_header header =
   map
     (fun s -> (s, 0, String.length s))
-    (Prettym.to_stream Header.Encoder.header header)
+    (Prettym.to_stream
+       ~margin:Utils.Constants.max_line_length
+       Header.Encoder.header header)
 
 let stream_of_header_and_encoded_body header stream =
   let content_encoding = Header.content_encoding header in

--- a/lib/serialize.ml
+++ b/lib/serialize.ml
@@ -179,7 +179,7 @@ let stream_of_header header =
     (fun s -> (s, 0, String.length s))
     (Prettym.to_stream
        ~margin:Utils.Constants.max_line_length
-       Header.Encoder.header header)
+       Header.Encoder.header header )
 
 let stream_of_header_and_encoded_body header stream =
   let content_encoding = Header.content_encoding header in

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -9,6 +9,8 @@ end
 module Constants = struct
   let meta_header_name = "X-Attachment-Converter"
   let meta_header_cont_dist = "base64"
+  let suggested_line_length = 78
+  let max_line_length = 998
 end
 
 let is_quoted str =


### PR DESCRIPTION
I removed the uses of `Result.get_ok`, but replaced one case with a new possible exception `HeaderRepresentationError`. It is my opinion that, if this is triggered it _should_ be critical, and it should be reported to the user that they should contact us if they ever get this error.

As a reminder, part of the motivation of this issue was to deal with a bug that triggering an uncaught exception. This came from the fact that `mrmime` was putting line breaks into long file names in order to maintain the recommended margin of 80 characters. Upping the allowed line length fixed this problem.