### PR TITLE
105 check header code

### DIFF
--- a/lib/configuration.ml
+++ b/lib/configuration.ml
@@ -138,7 +138,7 @@ module TransformData = struct
   let shell_command td = td.shell_command
   let convert_id td = td.convert_id
 
-  let to_string td =
+  let debug td =
     String.join ~sep:"\n"
       [ "target type     "
         ^ Mime_type.to_string (target_type td);

--- a/lib/configuration.mli
+++ b/lib/configuration.mli
@@ -35,7 +35,7 @@ module TransformData : sig
   val target_ext : t -> string
   val shell_command : t -> string
   val convert_id : t -> string
-  val to_string : t -> string
+  val debug : t -> string
 
   val make :
     target_type:Mime_type.t ->

--- a/lib/convert.ml
+++ b/lib/convert.ml
@@ -375,8 +375,7 @@ module Ocamlnet_parsetree = struct
     match header#field field_name with
     | exception Not_found -> None
     | exception e -> raise e
-    | hv_str ->
-      Some (Header.Field.Value.of_string hv_str)
+    | hv_str -> Some (Header.Field.Value.of_string hv_str)
 
   let meta_val = lookup_value Constants.meta_header_name
 

--- a/lib/convert.ml
+++ b/lib/convert.ml
@@ -192,7 +192,7 @@ module Mrmime_parsetree = struct
       ( Prettym.to_string ~margin:Constants.max_line_length
           Mrmime.Unstructured.Encoder.unstructured
       >> Header.Field.Value.of_string
-      >> Result.to_option )
+      >> fun x -> Some x )
         data
     | _ -> None
 
@@ -376,7 +376,7 @@ module Ocamlnet_parsetree = struct
     | exception Not_found -> None
     | exception e -> raise e
     | hv_str ->
-      Result.to_option (Header.Field.Value.of_string hv_str)
+      Some (Header.Field.Value.of_string hv_str)
 
   let meta_val = lookup_value Constants.meta_header_name
 

--- a/lib/dune
+++ b/lib/dune
@@ -19,7 +19,6 @@
   parsetree_error
   mbox
   header
-  value_error
   utils
   serialize
   skeleton

--- a/lib/error_intf.ml
+++ b/lib/error_intf.ml
@@ -3,8 +3,7 @@ type error =
   | Mime_type_error.t
   | Formats_error.t
   | Parsetree_error.t
-  | Dependency_error.t
-  | Value_error.t ]
+  | Dependency_error.t ]
 
 type t = error list
 

--- a/lib/header.ml
+++ b/lib/header.ml
@@ -1,7 +1,8 @@
-(* Note: This module contains an interface for working with headers
-   that is parsing-backend agnostic.  It is NOT fully functional, and
-   should NOT be used for general computations on headers.  In
-   particular, it does not follow RFC spec.  See the notes below. *)
+(* Note: This module contains an interface for working with
+   headers that is parsing-backend agnostic. It is NOT fully
+   functional, and should NOT be used for general
+   computations on headers. In particular, it does not
+   follow RFC spec. See the notes below. *)
 
 open Prelude
 open Utils
@@ -31,15 +32,17 @@ module Field = struct
       let map_attr f p = { p with attr = f p.attr }
       let map_value f p = { p with value = f p.value }
 
-      (* Note: `of_string` is only called on an header value parameter
-         in an email that has already been parsed, or on a hand-built
-         header value parameter.  Therefore, we assume it never fails.
-         This does NOT correctly fit the specification in RFC 2045. *)
+      (* Note: `of_string` is only called on an header value
+         parameter in an email that has already been parsed,
+         or on a hand-built header value parameter.
+         Therefore, we assume it never fails. This does NOT
+         correctly fit the specification in RFC 2045. *)
       let of_string str =
         let cut str =
           let open String in
           match cut ~sep:"=" str with
-          | left, Some right -> (trim whitespace left, trim whitespace right)
+          | left, Some right ->
+            (trim whitespace left, trim whitespace right)
           | left, None -> (trim whitespace left, "")
         in
         uncurry make (cut str)
@@ -57,16 +60,19 @@ module Field = struct
     (* Note: see the note for `Parameter.of_string` above *)
     let of_string str =
       let vs = String.cuts ~sep:";" str in
-      (* Note: according to RFC 2045, trimming is necessary because
-         whitespace is not allowed in attributes or values. *)
+      (* Note: according to RFC 2045, trimming is necessary
+         because whitespace is not allowed in attributes or
+         values. *)
       let vs = List.map String.(trim whitespace) vs in
       match List.map String.(trim whitespace) vs with
       | [] -> make ""
-      | v :: ps -> make ~params:(List.map Parameter.of_string ps) v
+      | v :: ps ->
+        make ~params:(List.map Parameter.of_string ps) v
 
-    (* Note: we hardcode CRLFs into the output of `to_string` because
-       it is never used in a full serialized email, it is only passed
-       into the email parsing backend. *)
+    (* Note: we hardcode CRLFs into the output of
+       `to_string` because it is never used in a full
+       serialized email, it is only passed into the email
+       parsing backend. *)
     let to_string { value; params } =
       let f curr p =
         curr ^ ";\r\n\t" ^ Parameter.to_string p
@@ -85,7 +91,7 @@ module Field = struct
           else lookup attr ps
       in
       lookup attr (params hv)
-end
+  end
 
   type t = { name : string; value : Value.t }
 

--- a/lib/header.ml
+++ b/lib/header.ml
@@ -1,3 +1,8 @@
+(* Note: This module contains an interface for working with headers
+   that is parsing-backend agnostic.  It is NOT fully functional, and
+   should NOT be used for general computations on headers.  In
+   particular, it does not follow RFC spec.  See the notes below. *)
+
 open Prelude
 open Utils
 module Trace = Error.T
@@ -26,13 +31,18 @@ module Field = struct
       let map_attr f p = { p with attr = f p.attr }
       let map_value f p = { p with value = f p.value }
 
+      (* Note: `of_string` is only called on an header value parameter
+         in an email that has already been parsed, or on a hand-built
+         header value parameter.  Therefore, we assume it never fails.
+         This does NOT correctly fit the specification in RFC 2045. *)
       let of_string str =
-        let cut_or_none str =
-          match String.cut ~sep:"=" str with
-          | left, Some right -> Some (left, right)
-          | _, None -> None
+        let cut str =
+          let open String in
+          match cut ~sep:"=" str with
+          | left, Some right -> (trim whitespace left, trim whitespace right)
+          | left, None -> (trim whitespace left, "")
         in
-        Option.map (uncurry make) (cut_or_none str)
+        uncurry make (cut str)
 
       let to_string { attr; value; quotes } =
         attr ^ "=" ^ if quotes then quoted value else value
@@ -44,28 +54,19 @@ module Field = struct
     let params hv = hv.params
     let make ?(params = []) value = { value; params }
 
+    (* Note: see the note for `Parameter.of_string` above *)
     let of_string str =
-      let open Value_error.Smart in
       let vs = String.cuts ~sep:";" str in
+      (* Note: according to RFC 2045, trimming is necessary because
+         whitespace is not allowed in attributes or values. *)
       let vs = List.map String.(trim whitespace) vs in
-      (* not sure if trimming is necessary or should be
-         done *)
-      let rec process ls =
-        match ls with
-        | [] -> Some []
-        | None :: _ -> None
-        | Some p :: ps ->
-          Option.map (fun xs -> p :: xs) (process ps)
-      in
-      match vs with
-      | [] -> Trace.throw param_parse_err
-      | value :: params -> (
-        match
-          process (List.map Parameter.of_string params)
-        with
-        | None -> Trace.throw param_parse_err
-        | Some params -> Ok (make ~params value) )
+      match List.map String.(trim whitespace) vs with
+      | [] -> make ""
+      | v :: ps -> make ~params:(List.map Parameter.of_string ps) v
 
+    (* Note: we hardcode CRLFs into the output of `to_string` because
+       it is never used in a full serialized email, it is only passed
+       into the email parsing backend. *)
     let to_string { value; params } =
       let f curr p =
         curr ^ ";\r\n\t" ^ Parameter.to_string p
@@ -84,30 +85,7 @@ module Field = struct
           else lookup attr ps
       in
       lookup attr (params hv)
-
-    let update_value new_value hv =
-      { hv with value = new_value }
-
-    let update_param attr f hv =
-      let cons_op x ls =
-        Option.either (List.snoc ls) ls x
-      in
-      let rec update ls =
-        match ls with
-        | [] -> cons_op (f None) []
-        | p :: ps ->
-          if Parameter.attr p = attr
-          then cons_op (f (Some p)) ps
-          else p :: update ps
-      in
-      { hv with params = update hv.params }
-
-    (* Note: updates in the case that the attribute already
-       appears as a paramater. *)
-    let add_param ?(quotes = false) attr value =
-      update_param attr
-        (k (Some (Parameter.make ~quotes attr value)))
-  end
+end
 
   type t = { name : string; value : Value.t }
 
@@ -115,19 +93,13 @@ module Field = struct
   let value fld = fld.value
   let make name value = { name; value }
 
+  (* Note: See the note for `Parameter.of_string` above *)
   let of_string str =
-    let open Value_error.Smart in
-    let ( let* ) = Result.( >>= ) in
     let name, optValueStr = String.cut ~sep:":" str in
     let name = String.(trim whitespace) name in
-    let* valueStr =
-      Option.(
-        to_result
-          (map String.(trim whitespace) optValueStr)
-          ~none:(Trace.new_list value_parse_err) )
-    in
-    let* value = Value.of_string valueStr in
-    Ok (make name value)
+    let valueStr = Option.default "" optValueStr in
+    let value = Value.of_string valueStr in
+    make name value
 
   let to_string fld =
     name fld ^ ": " ^ Value.to_string (value fld)
@@ -138,38 +110,12 @@ end
 
 type t = Field.t list
 
-let to_list l = l
 let of_list l = l
-
-let of_assoc_list ls =
-  let ( let* ) = Result.( >>= ) in
-  let f (n, v) curr =
-    let* l = Field.of_string (n ^ ": " ^ v) in
-    let* r = curr in
-    Ok (l :: r)
-  in
-  List.foldr f (Ok []) ls
 
 let to_assoc_list ls : (string * string) list =
   List.map Field.to_assoc ls
 
+(* Note: See the note for `Value.to_string` above. *)
 let to_string fld =
   String.join ~sep:"\r\n" (List.map Field.to_string fld)
   ^ "\r\n"
-
-let update g name hd =
-  let cons_op key x ls =
-    Option.either (fun y -> Field.make key y :: ls) ls x
-  in
-  let rec process ls =
-    match ls with
-    | [] -> cons_op name (g None) []
-    | fld :: fs ->
-      if Field.name fld = name
-      then
-        cons_op (Field.name fld)
-          (g (Some (Field.value fld)))
-          fs
-      else fld :: process fs
-  in
-  process hd

--- a/lib/header.mli
+++ b/lib/header.mli
@@ -9,7 +9,7 @@ module Field : sig
       val make : ?quotes:bool -> string -> string -> t
       val map_attr : (string -> string) -> t -> t
       val map_value : (string -> string) -> t -> t
-      val of_string : string -> t option
+      val of_string : string -> t
       val to_string : t -> string
     end
 
@@ -18,22 +18,11 @@ module Field : sig
     val value : t -> string
     val params : t -> Parameter.t list
     val make : ?params:Parameter.t list -> string -> t
-    val of_string : string -> (t, Error.t) result
+    val of_string : string -> t
     val to_string : t -> string
 
     val lookup_param :
       ?quotes:bool -> string -> t -> string option
-
-    val update_value : string -> t -> t
-
-    val update_param :
-      string ->
-      (Parameter.t option -> Parameter.t option) ->
-      t ->
-      t
-
-    val add_param :
-      ?quotes:bool -> string -> string -> t -> t
   end
 
   type t
@@ -42,23 +31,12 @@ module Field : sig
   val value : t -> Value.t
   val to_assoc : t -> string * string
   val make : string -> Value.t -> t
-  val of_string : string -> (t, Error.t) result
+  val of_string : string -> t
   val to_string : t -> string
 end
 
 type t
 
-val to_list : t -> Field.t list
 val of_list : Field.t list -> t
-
-val of_assoc_list :
-  (string * string) list -> (t, Error.t) result
-
 val to_assoc_list : t -> (string * string) list
 val to_string : t -> string
-
-val update :
-  (Field.Value.t option -> Field.Value.t option) ->
-  string ->
-  t ->
-  t

--- a/lib/value_error.ml
+++ b/lib/value_error.ml
@@ -1,6 +1,0 @@
-type t = [`ParameterParse | `ValueParse]
-
-module Smart = struct
-  let param_parse_err = `ParameterParse
-  let value_parse_err = `ValueParse
-end

--- a/tests/config_tests.ml
+++ b/tests/config_tests.ml
@@ -179,7 +179,7 @@ let check_wf_cs_or_extra_cs cs =
       | Ok tds ->
         "\n"
         ^ Prelude.String.join ~sep:"\n\n"
-            (List.map Configuration.TransformData.to_string
+            (List.map Configuration.TransformData.debug
                tds )
         ^ "\n"
     in
@@ -244,7 +244,7 @@ let check_double_entry_cs =
     | Ok tds ->
       "\n"
       ^ Prelude.String.join ~sep:"\n\n"
-          (List.map Configuration.TransformData.to_string
+          (List.map Configuration.TransformData.debug
              tds )
       ^ "\n"
   in

--- a/tests/config_tests.ml
+++ b/tests/config_tests.ml
@@ -179,8 +179,7 @@ let check_wf_cs_or_extra_cs cs =
       | Ok tds ->
         "\n"
         ^ Prelude.String.join ~sep:"\n\n"
-            (List.map Configuration.TransformData.debug
-               tds )
+            (List.map Configuration.TransformData.debug tds)
         ^ "\n"
     in
     assert_equal (Ok value)
@@ -244,8 +243,7 @@ let check_double_entry_cs =
     | Ok tds ->
       "\n"
       ^ Prelude.String.join ~sep:"\n\n"
-          (List.map Configuration.TransformData.debug
-             tds )
+          (List.map Configuration.TransformData.debug tds)
       ^ "\n"
   in
   let expected = Ok [ e2; e1 ] in

--- a/tests/field_tests.ml
+++ b/tests/field_tests.ml
@@ -16,14 +16,11 @@ let fld1 =
 let str2 = " Test : test ; \r\n \ta1=v1; \r\n\ta2=\"v2\""
 
 let of_string_test1 =
-  check_eq_basic "basic of_string test" (Ok fld1)
+  check_eq_basic "basic of_string test" fld1
     (F.of_string str1)
 
-let of_string_test2 =
-  check_is_ok (F.of_string str2) "(of_string str2)"
-
 let of_string_test3 =
-  check_eq_basic "of_string with spaces test" (Ok fld1)
+  check_eq_basic "of_string with spaces test" fld1
     (F.of_string str2)
 
 let to_string_test1 =
@@ -38,7 +35,6 @@ let to_assoc_test1 =
 let tests =
   "test suite for fields"
   >::: [ of_string_test1;
-         of_string_test2;
          of_string_test3;
          to_string_test1;
          to_assoc_test1

--- a/tests/field_value_tests.ml
+++ b/tests/field_value_tests.ml
@@ -20,16 +20,14 @@ let of_string_test1 =
     V.make ~params:[ param1; param2 ] "attachment"
   in
   let real = V.of_string basic_cont_dis in
-  let test _ = assert_equal expected real
-  in
+  let test _ = assert_equal expected real in
   "basic of_string of basic_cont_dis test" >:: test
 
 let cd = V.of_string basic_cont_dis
 
 let to_string_test1 =
   check_eq_basic "basic to_string of basic_cont_dis test"
-    basic_cont_dis
-    (V.to_string cd)
+    basic_cont_dis (V.to_string cd)
 
 let to_string_test2 =
   check_eq_basic "basic to_string without params"

--- a/tests/field_value_tests.ml
+++ b/tests/field_value_tests.ml
@@ -19,11 +19,8 @@ let of_string_test1 =
   let expected =
     V.make ~params:[ param1; param2 ] "attachment"
   in
-  let real_result = V.of_string basic_cont_dis in
-  let test _ =
-    match real_result with
-    | Error _ -> assert_failure "got an error"
-    | Ok real -> assert_equal expected real
+  let real = V.of_string basic_cont_dis in
+  let test _ = assert_equal expected real
   in
   "basic of_string of basic_cont_dis test" >:: test
 
@@ -31,99 +28,27 @@ let cd = V.of_string basic_cont_dis
 
 let to_string_test1 =
   check_eq_basic "basic to_string of basic_cont_dis test"
-    (Ok basic_cont_dis)
-    (Result.map V.to_string cd)
+    basic_cont_dis
+    (V.to_string cd)
 
 let to_string_test2 =
   check_eq_basic "basic to_string without params"
-    (Ok "attachment")
-    (Result.map V.to_string (V.of_string "attachment"))
+    "attachment"
+    (V.to_string (V.of_string "attachment"))
 
 let lookup_param_test1 =
   let test _ =
-    match cd with
-    | Error _ -> assert_failure "cd is none"
-    | Ok cd -> (
-      match V.lookup_param "filename" cd with
-      | None -> assert_failure "Lookup failed"
-      | Some v -> assert_equal "test.gif" v ~printer:id )
+    match V.lookup_param "filename" cd with
+    | None -> assert_failure "Lookup failed"
+    | Some v -> assert_equal "test.gif" v ~printer:id
   in
   "basics lookup test" >:: test
-
-let update_tests =
-  let param1 = P.make "filename*" "utf-8''test.gif" in
-  let param2 = P.make ~quotes:true "filename" "test.gif" in
-  let param3 = P.make "filename" "ok.gif" in
-  let param4 = P.make ~quotes:true "whatever" "ok.gif" in
-  let test1 =
-    check_eq_basic "basic update_value test"
-      (Ok (V.make ~params:[ param1; param2 ] "inline"))
-      (Result.map (V.update_value "inline") cd)
-  in
-  let test2 =
-    check_eq_basic "basic update_param test"
-      (Result.map
-         (V.make ~params:[ param1; param3 ] << V.value)
-         cd )
-      (Result.map
-         (V.update_param "filename" (fun _ -> Some param3))
-         cd )
-  in
-  let test3 =
-    check_eq_basic "basic update_param remove test"
-      (Result.map (V.make ~params:[ param1 ] << V.value) cd)
-      (Result.map
-         (V.update_param "filename" (fun _ -> None))
-         cd )
-  in
-  let test4 =
-    check_eq_basic "basic update_param no op test" cd
-      (Result.map
-         (V.update_param "file" (fun _ -> None))
-         cd )
-  in
-  let test5 =
-    check_eq_basic "basic add_param test"
-      (Result.map
-         ( V.make ~params:[ param1; param2; param4 ]
-         << V.value )
-         cd )
-      (Result.map
-         (V.add_param ~quotes:true "whatever" "ok.gif")
-         cd )
-  in
-  let test6 =
-    check_eq_basic "basic add_param with quotes test"
-      (Result.map
-         ( V.make
-             ~params:
-               [ param1;
-                 param2;
-                 P.make ~quotes:true (P.attr param4)
-                   (P.value param4)
-               ]
-         << V.value )
-         cd )
-      (Result.map
-         (V.add_param ~quotes:true "whatever" "ok.gif")
-         cd )
-  in
-  let test7 =
-    check_eq_basic "add_param as update test"
-      (Result.map
-         (V.make ~params:[ param1; param3 ] << V.value)
-         cd )
-      (Result.map (V.add_param "filename" "ok.gif") cd)
-  in
-  "all update tests"
-  >::: [ test1; test2; test3; test4; test5; test6; test7 ]
 
 let tests =
   "test suite for header field values"
   >::: [ of_string_test1;
          to_string_test1;
          to_string_test2;
-         update_tests;
          lookup_param_test1
        ]
 

--- a/tests/header_tests.ml
+++ b/tests/header_tests.ml
@@ -35,7 +35,8 @@ let asc1 =
   ]
 
 (* let of_assoc_list_test1 = *)
-(*   check_is_ok (H.of_assoc_list asc1) "(of_assoc_list asc1)" *)
+(* check_is_ok (H.of_assoc_list asc1) "(of_assoc_list
+   asc1)" *)
 
 (* let of_assoc_list_test2 = *)
 (*   check_eq_basic "basic of_assoc_list test" (Ok hd1) *)
@@ -65,7 +66,7 @@ let tests =
   >::: [ (* of_assoc_list_test1; *)
          (* of_assoc_list_test2; *)
          to_assoc_list_test1;
-         to_string_test1;
+         to_string_test1
          (* update_test1; *)
          (* update_test2 *)
        ]

--- a/tests/header_tests.ml
+++ b/tests/header_tests.ml
@@ -24,22 +24,22 @@ let f2 =
        ~params:[ P.make ~quotes:true "a2" "v2" ]
        "test2" )
 
-let f3 = F.make "Test2" v1
+(* let f3 = F.make "Test2" v1 *)
 let hd1 = H.of_list [ f1; f2 ]
-let hd2 = H.of_list [ f1 ]
-let hd3 = H.of_list [ f1; f3 ]
+(* let hd2 = H.of_list [ f1 ] *)
+(* let hd3 = H.of_list [ f1; f3 ] *)
 
 let asc1 =
   [ ("Test1", "test1;\r\n\ta1=v1");
     ("Test2", "test2;\r\n\ta2=\"v2\"")
   ]
 
-let of_assoc_list_test1 =
-  check_is_ok (H.of_assoc_list asc1) "(of_assoc_list asc1)"
+(* let of_assoc_list_test1 = *)
+(*   check_is_ok (H.of_assoc_list asc1) "(of_assoc_list asc1)" *)
 
-let of_assoc_list_test2 =
-  check_eq_basic "basic of_assoc_list test" (Ok hd1)
-    (H.of_assoc_list asc1)
+(* let of_assoc_list_test2 = *)
+(*   check_eq_basic "basic of_assoc_list test" (Ok hd1) *)
+(*     (H.of_assoc_list asc1) *)
 
 let to_assoc_list_test1 =
   check_eq_basic "basic to_assoc_list test" asc1
@@ -52,22 +52,22 @@ let to_string_test1 =
   let test _ = assert_equal expected real ~printer in
   "basic to_string test" >:: test
 
-let update_test1 =
-  check_eq_basic "basic remove test" hd2
-    (H.update (fun _ -> None) "Test2" hd1)
+(* let update_test1 = *)
+(*   check_eq_basic "basic remove test" hd2 *)
+(*     (H.update (fun _ -> None) "Test2" hd1) *)
 
-let update_test2 =
-  check_eq_basic "basic update test" hd3
-    (H.update (fun _ -> Some v1) "Test2" hd1)
+(* let update_test2 = *)
+(*   check_eq_basic "basic update test" hd3 *)
+(*     (H.update (fun _ -> Some v1) "Test2" hd1) *)
 
 let tests =
   "test suite for fields"
-  >::: [ of_assoc_list_test1;
-         of_assoc_list_test2;
+  >::: [ (* of_assoc_list_test1; *)
+         (* of_assoc_list_test2; *)
          to_assoc_list_test1;
          to_string_test1;
-         update_test1;
-         update_test2
+         (* update_test1; *)
+         (* update_test2 *)
        ]
 
 let _ = run_test_tt_main tests

--- a/tests/param_tests.ml
+++ b/tests/param_tests.ml
@@ -28,21 +28,15 @@ let map_test2 =
 let p_str1 = "param1=value1"
 let p_str2 = "p=\"v\""
 
-let of_string_test1 =
-  check_is_something (of_string p_str1) "(of_string p_str1)"
-
 let of_string_test2 =
-  let out = Option.get (of_string p_str1) in
+  let out = of_string p_str1 in
   "of string, no quotes"
   >::: [ check_eq_basic "attr check" "param1" (attr out);
          check_eq_basic "value check" "value1" (value out)
        ]
 
-let of_string_test3 =
-  check_is_something (of_string p_str2) "(of_string p_str2)"
-
 let of_string_test4 =
-  let out = Option.get (of_string p_str2) in
+  let out = of_string p_str2 in
   "of string, with quotes"
   >::: [ check_eq_basic "attr check" "p" (attr out);
          check_eq_basic "value check" "v" (value out)
@@ -68,9 +62,7 @@ let tests =
          value_test2;
          map_test1;
          map_test2;
-         of_string_test1;
          of_string_test2;
-         of_string_test3;
          of_string_test4;
          to_string_test1;
          to_string_test2;


### PR DESCRIPTION
I pruned a fair amount of the header code when I realized all it was really doing was giving us an interface to work with values of unstructured header fields.

The one larger side effect of this is that I decided it would be simpler if the `of_string` functions didn't throw errors. This is a bit of a strong choice, but I think it makes more sense for how the `of_string` function is used.

I've included a lot of comments in `header.ml` to note how the functions should be used.

Ultimately I hope that in the long run a lot of the code in `header.ml` will be made obsolete by PRs to MrMime.