### PR TITLE
110 required body in mrmime parsetree

### DIFF
--- a/lib/convert.ml
+++ b/lib/convert.ml
@@ -462,7 +462,8 @@ module Ocamlnet_parsetree = struct
             Option.default "NONAME" (attachment_name att) )
       )
     | `Parts parts ->
-      Multipart (List.map (Option.some << to_skeleton) parts)
+      Multipart
+        (List.map (Option.some << to_skeleton) parts)
 end
 
 module _ : PARSETREE = Ocamlnet_parsetree

--- a/tests/dune
+++ b/tests/dune
@@ -6,6 +6,6 @@
   field_value_tests
   field_tests
   header_tests
-  serialize_tests
+  ;  serialize_tests
   dependency_tests)
  (libraries lib ounit2))

--- a/tests/dune
+++ b/tests/dune
@@ -6,6 +6,6 @@
   field_value_tests
   field_tests
   header_tests
-  ;  serialize_tests
+  serialize_tests
   dependency_tests)
  (libraries lib ounit2))

--- a/tests/serialize_tests.ml
+++ b/tests/serialize_tests.ml
@@ -15,8 +15,8 @@ let basic_skel2 =
           (Message
              (Message
                 (Multipart
-                   [ Some Body; Some dummy_attachment ]
-                ) ) );
+                   [ Some Body; Some dummy_attachment ] ) )
+          );
         Some dummy_attachment
       ] )
 

--- a/tests/serialize_tests.ml
+++ b/tests/serialize_tests.ml
@@ -3,24 +3,22 @@ open Utils
 open Lib
 
 let basic_skel1 =
-  Skeleton.(
-    Some (Multipart [ Some Body; Some dummy_attachment ]) )
+  Skeleton.(Multipart [ Some Body; Some dummy_attachment ])
 
 let basic_skel2 =
   Skeleton.(
-    Some
-      (Multipart
-         [ Some Body;
-           Some Body;
-           Some dummy_attachment;
-           Some
+    Multipart
+      [ Some Body;
+        Some Body;
+        Some dummy_attachment;
+        Some
+          (Message
              (Message
-                (Message
-                   (Multipart
-                      [ Some Body; Some dummy_attachment ]
-                   ) ) );
-           Some dummy_attachment
-         ] ) )
+                (Multipart
+                   [ Some Body; Some dummy_attachment ]
+                ) ) );
+        Some dummy_attachment
+      ] )
 
 let tests =
   "test suite for serialization"


### PR DESCRIPTION
I've rewritten the mrmime parsetree mail representation so that the body is required. This required just a bit of messing with the logic. This also made it easier to get rid of the `Option.get`s sprinkled in the code (written by me early in the project, learned by lesson there).

This also allows to handle one problem case, namely displaying the skeleton when the attachment does not have a name.