### PR TITLE
109 revamp mime type representation

### DIFF
--- a/lib/error.ml
+++ b/lib/error.ml
@@ -19,4 +19,9 @@ module T = struct
     match x with
     | Some x -> Ok x
     | None -> throw err
+
+  let of_result err x =
+    match x with
+    | Ok x -> Ok x
+    | Error _ -> throw err
 end

--- a/lib/error.mli
+++ b/lib/error.mli
@@ -7,5 +7,7 @@ module T : sig
   val new_list : [< error] -> t
   val throw : [< error] -> ('a, t) result
   val of_option : [< error] -> 'a option -> ('a, t) result
-  val of_result : [< error] -> ('a, 'e) result -> ('a, t) result
+
+  val of_result :
+    [< error] -> ('a, 'e) result -> ('a, t) result
 end

--- a/lib/error.mli
+++ b/lib/error.mli
@@ -7,4 +7,5 @@ module T : sig
   val new_list : [< error] -> t
   val throw : [< error] -> ('a, t) result
   val of_option : [< error] -> 'a option -> ('a, t) result
+  val of_result : [< error] -> ('a, 'e) result -> ('a, t) result
 end

--- a/lib/mime_type.mli
+++ b/lib/mime_type.mli
@@ -1,22 +1,16 @@
 module Type : sig
   type t
 
-  val to_string : t -> string
-  val of_string : string -> t
-  val application : t
-  val text : t
-  val image : t
+  val of_string : string -> (t, Error.t) result
 end
 
 module Subtype : sig
   type t
 
-  val to_string : t -> string
-  val of_string : string -> t
   val pdf : t
   val plain : t
   val msword : t
-  val docx_subty : t
+  val docx : t
   val xls : t
   val xlsx : t
   val tsv : t
@@ -28,8 +22,8 @@ end
 
 type t
 
-val type_of : t -> Type.t
-val subtype : t -> Subtype.t
+val ty : t -> Type.t
+val subty : t -> Subtype.t
 val make : Type.t -> Subtype.t -> t
 val to_string : t -> string
 val of_string : string -> (t, Error.t) result


### PR DESCRIPTION
This is slightly lower priority, but I thought it would be worthwhile to rewrite the config code so that it used `mrmime`s representation and parser. We discussed a bit the potential downsides of this (e.g., if `mrmime` stops being supported) but it simplifies our code a fair amount, handles some issues with our naive parsings method, makes our code more robust, and would not be difficult to port directly into the project should `mrmime` go bust.